### PR TITLE
remove printer model field

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,6 @@ The web interface also provides REST API endpoints:
 - `GET /api/print-errors` - Get all unacknowledged print errors
 - `POST /api/print-errors/{id}/acknowledge` - Acknowledge a print error
 - `GET/POST /api/printers`, `PUT/DELETE /api/printers/{id}` - Manage printer configurations
-- `POST /api/detect_printer` - Detect a printer's model via PrusaLink
 - `GET/POST /api/config` - Read and update configuration
 - `GET /api/nfc/assign` - Handle NFC tag scans (spool, location, or both in one URL)
 - `GET /api/nfc/urls` - Get all NFC URLs with QR codes

--- a/bridge.go
+++ b/bridge.go
@@ -134,7 +134,6 @@ func (b *FilamentBridge) initDatabase() error {
 		`CREATE TABLE IF NOT EXISTS printer_configs (
 			printer_id TEXT PRIMARY KEY,
 			name TEXT NOT NULL,
-			model TEXT,
 			ip_address TEXT NOT NULL,
 			api_key TEXT,
 			toolheads INTEGER DEFAULT 1,
@@ -197,6 +196,15 @@ func (b *FilamentBridge) initDatabase() error {
 			recorded_at TIMESTAMP NOT NULL,
 			PRIMARY KEY (printer_id, job_id)
 		)`,
+	}
+
+	// Pre-release builds stored a cosmetic printer model; drop the leftover
+	// column from existing databases (it was display-only, nothing reads it).
+	var modelCol string
+	if err := b.db.QueryRow(`SELECT name FROM pragma_table_info('printer_configs') WHERE name='model'`).Scan(&modelCol); err == nil {
+		if _, err := b.db.Exec(`ALTER TABLE printer_configs DROP COLUMN model`); err != nil {
+			return fmt.Errorf("failed to drop model column: %w", err)
+		}
 	}
 
 	// Pre-release builds named the recorded_jobs table billed_jobs; rename it
@@ -380,7 +388,7 @@ func (b *FilamentBridge) SetAutoAssignPreviousSpoolLocation(location string) err
 
 // GetAllPrinterConfigs gets all printer configurations
 func (b *FilamentBridge) GetAllPrinterConfigs() (map[string]PrinterConfig, error) {
-	rows, err := b.db.Query("SELECT printer_id, name, model, ip_address, api_key, toolheads FROM printer_configs")
+	rows, err := b.db.Query("SELECT printer_id, name, ip_address, api_key, toolheads FROM printer_configs")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get printer configs: %w", err)
 	}
@@ -388,14 +396,13 @@ func (b *FilamentBridge) GetAllPrinterConfigs() (map[string]PrinterConfig, error
 
 	configs := make(map[string]PrinterConfig)
 	for rows.Next() {
-		var printerID, name, model, ipAddress, apiKey string
+		var printerID, name, ipAddress, apiKey string
 		var toolheads int
-		if err := rows.Scan(&printerID, &name, &model, &ipAddress, &apiKey, &toolheads); err != nil {
+		if err := rows.Scan(&printerID, &name, &ipAddress, &apiKey, &toolheads); err != nil {
 			return nil, fmt.Errorf("failed to scan printer config row: %w", err)
 		}
 		configs[printerID] = PrinterConfig{
 			Name:      name,
-			Model:     model,
 			IPAddress: ipAddress,
 			APIKey:    apiKey,
 			Toolheads: toolheads,
@@ -411,9 +418,9 @@ func (b *FilamentBridge) SavePrinterConfig(printerID string, config PrinterConfi
 	defer b.mutex.Unlock()
 
 	_, err := b.db.Exec(`
-		INSERT OR REPLACE INTO printer_configs (printer_id, name, model, ip_address, api_key, toolheads)
-		VALUES (?, ?, ?, ?, ?, ?)
-	`, printerID, config.Name, config.Model, config.IPAddress, config.APIKey, config.Toolheads)
+		INSERT OR REPLACE INTO printer_configs (printer_id, name, ip_address, api_key, toolheads)
+		VALUES (?, ?, ?, ?, ?)
+	`, printerID, config.Name, config.IPAddress, config.APIKey, config.Toolheads)
 	if err != nil {
 		return fmt.Errorf("failed to save printer config: %w", err)
 	}

--- a/config.go
+++ b/config.go
@@ -12,7 +12,6 @@ import (
 // PrinterConfig represents configuration for a single printer
 type PrinterConfig struct {
 	Name      string `json:"name"`
-	Model     string `json:"model"`
 	IPAddress string `json:"ip_address"`
 	APIKey    string `json:"api_key,omitempty"`
 	Toolheads int    `json:"toolheads"`
@@ -112,7 +111,6 @@ func LoadConfig(bridge *FilamentBridge) (*Config, error) {
 		// Fallback to empty config
 		config.Printers["no_printers"] = PrinterConfig{
 			Name:      "No Printers Configured",
-			Model:     "Unknown",
 			IPAddress: "",
 			APIKey:    "",
 			Toolheads: 0,
@@ -127,7 +125,6 @@ func LoadConfig(bridge *FilamentBridge) (*Config, error) {
 		// Live printer status will be handled by the monitoring cycle
 		config.Printers[printerID] = PrinterConfig{
 			Name:      printerConfig.Name,
-			Model:     printerConfig.Model,
 			IPAddress: printerConfig.IPAddress,
 			APIKey:    printerConfig.APIKey,
 			Toolheads: printerConfig.Toolheads,
@@ -138,7 +135,6 @@ func LoadConfig(bridge *FilamentBridge) (*Config, error) {
 	if len(config.Printers) == 0 {
 		config.Printers["no_printers"] = PrinterConfig{
 			Name:      "No Printers Configured",
-			Model:     "Unknown",
 			IPAddress: "",
 			APIKey:    "",
 			Toolheads: 0,

--- a/constants.go
+++ b/constants.go
@@ -51,21 +51,3 @@ const (
 	SpoolmanTimeout              = 10  // seconds
 )
 
-// Printer model detection patterns
-const (
-	ModelCorePattern = "core"
-	ModelXLPattern   = "xl"
-	ModelMK4Pattern  = "mk4"
-	ModelMK3Pattern  = "mk3"
-	ModelMiniPattern = "mini"
-)
-
-// Printer model names
-const (
-	ModelCoreOne  = "CORE One"
-	ModelXL       = "XL"
-	ModelMK4      = "MK4"
-	ModelMK35     = "MK3.5"
-	ModelMiniPlus = "MINI+"
-	ModelUnknown  = "Unknown"
-)

--- a/prusalink.go
+++ b/prusalink.go
@@ -86,15 +86,6 @@ type PrusaLinkJob struct {
 	} `json:"filament,omitempty"`
 }
 
-// PrusaLinkInfo represents the printer info response from PrusaLink
-type PrusaLinkInfo struct {
-	Hostname         string  `json:"hostname"`
-	Serial           string  `json:"serial"`
-	NozzleDiameter   float64 `json:"nozzle_diameter"`
-	MMU              bool    `json:"mmu"`
-	MinExtrusionTemp int     `json:"min_extrusion_temp"`
-}
-
 // NewPrusaLinkClient creates a new PrusaLink client
 func NewPrusaLinkClient(ipAddress, apiKey string, timeout, fileDownloadTimeout int) *PrusaLinkClient {
 	// Create a custom dialer with timeout for DNS resolution
@@ -189,35 +180,6 @@ func (c *PrusaLinkClient) GetJobInfo() (*PrusaLinkJob, error) {
 	}
 
 	return &job, nil
-}
-
-// GetPrinterInfo retrieves the printer information. Failures are reported via
-// the returned error; callers decide what to log.
-func (c *PrusaLinkClient) GetPrinterInfo() (*PrusaLinkInfo, error) {
-	req, err := http.NewRequest("GET", c.baseURL+"/api/v1/info", nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create printer info request: %w", err)
-	}
-
-	c.addAPIKey(req)
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get printer info from PrusaLink: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("PrusaLink API error: %d - %s", resp.StatusCode, string(body))
-	}
-
-	var info PrusaLinkInfo
-	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
-		return nil, fmt.Errorf("failed to decode printer info response: %w", err)
-	}
-
-	return &info, nil
 }
 
 // GetGcodeFile downloads the G-code file for a completed print job

--- a/static/js/printers.js
+++ b/static/js/printers.js
@@ -46,7 +46,7 @@ function loadPrinters() {
                     printerCard.innerHTML = `
                         <h3>${printer.name || 'Unknown Printer'}</h3>
                         <div class="printer-info">
-                            <div><strong>Model:</strong> ${printer.model || 'Unknown'} (${printer.toolheads || 1} toolhead${printer.toolheads > 1 ? 's' : ''})</div>
+                            <div><strong>Toolheads:</strong> ${printer.toolheads || 1}</div>
                             <div><strong>Address:</strong> ${printer.ip_address || 'Not configured'}</div>
                             <div><strong>API Key:</strong> ${printer.api_key ? '••••••••' : 'Not configured'}</div>
                         </div>
@@ -159,10 +159,25 @@ document.getElementById('addPrinterForm').addEventListener('submit', function(e)
     const submitButton = this.querySelector('button[type="submit"]');
     const originalText = submitButton.textContent;
     submitButton.disabled = true;
-    submitButton.textContent = 'Detecting model...';
+    submitButton.textContent = 'Adding...';
     
-    // First detect printer model, then add printer
-    detectModelAndAddPrinter(name, ipAddress, apiKey, toolheads, submitButton, originalText);
+    addPrinter({
+        name: name,
+        ip_address: ipAddress,
+        api_key: apiKey,
+        toolheads: toolheads
+    })
+    .then(() => {
+        // Success - close modal and refresh
+        closeAddPrinterModal();
+        loadPrinters();
+    })
+    .catch(error => {
+        // Reset button state
+        submitButton.disabled = false;
+        submitButton.textContent = originalText;
+        alert('Error adding printer: ' + error.message);
+    });
 });
 
 // Handle edit form submission
@@ -172,7 +187,6 @@ document.getElementById('editPrinterForm').addEventListener('submit', function(e
     const formData = new FormData(this);
     const printerId = formData.get('printerId');
     const name = formData.get('name');
-    const model = formData.get('model');
     const ipAddress = formData.get('ip_address');
     const apiKey = formData.get('api_key');
     const toolheads = parseInt(formData.get('toolheads'));
@@ -197,7 +211,6 @@ document.getElementById('editPrinterForm').addEventListener('submit', function(e
     // Create printer config
     const printerConfig = {
         name: name,
-        model: model,
         ip_address: ipAddress,
         api_key: apiKey,
         toolheads: toolheads
@@ -229,53 +242,6 @@ document.getElementById('editPrinterForm').addEventListener('submit', function(e
     });
 });
 
-function detectModelAndAddPrinter(name, ipAddress, apiKey, toolheads, submitButton, originalText) {
-    // Detect printer model only
-    fetch('/api/detect_printer', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({
-            ip_address: ipAddress,
-            api_key: apiKey
-        })
-    })
-    .then(response => response.json())
-    .then(data => {
-        // Check if there was an error (but still proceed if detection failed)
-        if (data.error) {
-            throw new Error(data.error);
-        }
-        
-        // Show warning if detection failed but still proceed
-        if (!data.detected && data.warning) {
-            console.warn('Printer detection failed:', data.warning);
-        }
-        
-        // Create printer config with detected model (or "Unknown" if detection failed)
-        const printerConfig = {
-            name: name,
-            model: data.model || "Unknown",
-            ip_address: ipAddress,
-            api_key: apiKey,
-            toolheads: toolheads
-        };
-        
-        // Add the printer
-        return addPrinter(printerConfig);
-    })
-    .then(() => {
-        // Success - close modal and refresh
-        closeAddPrinterModal();
-        loadPrinters();
-    })
-    .catch(error => {
-        // Reset button state
-        submitButton.disabled = false;
-        submitButton.textContent = originalText;
-        alert('Error adding printer: ' + error.message);
-    });
-}
-
 function editPrinter(printerId) {
     // Get the current printer data
     fetch('/api/printers')
@@ -290,7 +256,6 @@ function editPrinter(printerId) {
             // Populate the edit form with current data
             document.getElementById('editPrinterId').value = printerId;
             document.getElementById('editPrinterName').value = printer.name || '';
-            document.getElementById('editPrinterModel').value = printer.model || '';
             document.getElementById('editPrinterIP').value = printer.ip_address || '';
             document.getElementById('editPrinterAPIKey').value = printer.api_key || '';
             document.getElementById('editPrinterToolheads').value = printer.toolheads || 1;

--- a/templates/modals.html
+++ b/templates/modals.html
@@ -22,18 +22,6 @@
                 <small>Found in PrusaLink settings on your printer</small>
             </div>
             <div class="form-group">
-                <label for="printerModel">Printer Model</label>
-                <select id="printerModel" name="model">
-                    <option value="MK3S+">MK3S+</option>
-                    <option value="MK3S">MK3S</option>
-                    <option value="MINI+">MINI+</option>
-                    <option value="MINI">MINI</option>
-                    <option value="XL">XL</option>
-                    <option value="Other">Other</option>
-                </select>
-                <small>Select your printer model (auto-detected if possible)</small>
-            </div>
-            <div class="form-group">
                 <label for="printerToolheads">Number of Toolheads</label>
                 <select id="printerToolheads" name="toolheads">
                     <option value="1">1 Toolhead</option>
@@ -72,17 +60,6 @@
             <div class="form-group">
                 <label for="editPrinterAPIKey">API Key *</label>
                 <input type="password" id="editPrinterAPIKey" name="api_key" required>
-            </div>
-            <div class="form-group">
-                <label for="editPrinterModel">Printer Model</label>
-                <select id="editPrinterModel" name="model">
-                    <option value="MK3S+">MK3S+</option>
-                    <option value="MK3S">MK3S</option>
-                    <option value="MINI+">MINI+</option>
-                    <option value="MINI">MINI</option>
-                    <option value="XL">XL</option>
-                    <option value="Other">Other</option>
-                </select>
             </div>
             <div class="form-group">
                 <label for="editPrinterToolheads">Number of Toolheads</label>

--- a/templates/status.html
+++ b/templates/status.html
@@ -56,7 +56,7 @@
                 </span>
             </div>
             
-            <p><strong>Model:</strong> {{$printerConfig.Model}} ({{$printerConfig.Toolheads}} toolhead{{if ne $printerConfig.Toolheads 1}}s{{end}})</p>
+            <p><strong>Toolheads:</strong> {{$printerConfig.Toolheads}}</p>
 
             <div class="mapping-section">
                 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">

--- a/web.go
+++ b/web.go
@@ -166,7 +166,6 @@ func (ws *WebServer) setupRoutes() {
 		api.DELETE("/printers/:id", ws.deletePrinterHandler)
 		api.GET("/printers/:id/toolheads", ws.getToolheadNamesHandler)
 		api.PUT("/printers/:id/toolheads/:toolhead_id", ws.updateToolheadNameHandler)
-		api.POST("/detect_printer", ws.detectPrinterHandler)
 		api.GET("/print-errors", ws.getPrintErrorsHandler)
 		api.POST("/print-errors/:id/acknowledge", ws.acknowledgePrintErrorHandler)
 		api.GET("/print-history", ws.getPrintHistoryHandler)
@@ -712,7 +711,6 @@ func (ws *WebServer) getPrintersHandler(c *gin.Context) {
 	for printerID, printerConfig := range printerConfigs {
 		printerData := map[string]interface{}{
 			"name":       printerConfig.Name,
-			"model":      printerConfig.Model,
 			"ip_address": printerConfig.IPAddress,
 			"api_key":    printerConfig.APIKey,
 			"toolheads":  printerConfig.Toolheads,
@@ -805,22 +803,6 @@ func (ws *WebServer) updatePrinterHandler(c *gin.Context) {
 	if err := validateAddress(printerConfig.IPAddress); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
-	}
-
-	// Auto-detect model if address or API key changed, or if model is currently "Unknown"
-	if printerConfig.Model == "" || printerConfig.Model == ModelUnknown {
-		// Create PrusaLink client for detection
-		client := NewPrusaLinkClient(printerConfig.IPAddress, printerConfig.APIKey, 10, 60) // Use default timeouts for detection
-
-		printerInfo, err := client.GetPrinterInfo()
-		if err != nil {
-			log.Printf("Warning: could not auto-detect model for %s: %v (keeping model: %s)",
-				printerConfig.IPAddress, err, printerConfig.Model)
-		} else if detectedModel := detectPrinterModel(printerInfo.Hostname); detectedModel != ModelUnknown {
-			log.Printf("Detected printer model for %s: %s (hostname '%s')",
-				printerConfig.IPAddress, detectedModel, printerInfo.Hostname)
-			printerConfig.Model = detectedModel
-		}
 	}
 
 	// Save the updated printer configuration
@@ -945,73 +927,6 @@ func (ws *WebServer) updateToolheadNameHandler(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"message": "Toolhead name updated successfully"})
-}
-
-// detectPrinterModel detects printer model from hostname
-func detectPrinterModel(hostname string) string {
-	hostnameLower := strings.TrimSpace(strings.ToLower(hostname))
-
-	switch {
-	case strings.Contains(hostnameLower, ModelCorePattern):
-		return ModelCoreOne
-	case strings.Contains(hostnameLower, ModelXLPattern):
-		return ModelXL
-	case strings.Contains(hostnameLower, ModelMK4Pattern):
-		return ModelMK4
-	case strings.Contains(hostnameLower, ModelMK3Pattern):
-		return ModelMK35
-	case strings.Contains(hostnameLower, ModelMiniPattern):
-		return ModelMiniPlus
-	}
-	return ModelUnknown
-}
-
-// detectPrinterHandler detects printer model from PrusaLink API
-func (ws *WebServer) detectPrinterHandler(c *gin.Context) {
-	var req struct {
-		IPAddress string `json:"ip_address" binding:"required"`
-		APIKey    string `json:"api_key" binding:"required"`
-	}
-
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid JSON"})
-		return
-	}
-
-	// Validate address
-	if err := validateAddress(req.IPAddress); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-
-	// Create PrusaLink client
-	client := NewPrusaLinkClient(req.IPAddress, req.APIKey, 10, 60) // Use default timeouts for detection
-
-	// Try to get printer info, but don't fail if it times out
-	printerInfo, err := client.GetPrinterInfo()
-	if err != nil {
-		log.Printf("Warning: printer detection failed for %s: %v", req.IPAddress, err)
-		// If API call fails, return default values instead of error
-		// This allows users to add printers even if they're offline
-		c.JSON(http.StatusOK, gin.H{
-			"model":    ModelUnknown,
-			"hostname": "Unknown",
-			"detected": false,
-			"warning":  "Could not connect to printer. You can still add it manually.",
-		})
-		return
-	}
-
-	// Use shared model detection function
-	model := detectPrinterModel(printerInfo.Hostname)
-	log.Printf("Detected printer at %s: hostname '%s', model %s", req.IPAddress, printerInfo.Hostname, model)
-
-	// Return detected information (toolheads will be provided by user)
-	c.JSON(http.StatusOK, gin.H{
-		"model":    model,
-		"hostname": printerInfo.Hostname,
-		"detected": true,
-	})
 }
 
 // testSpoolmanConnectionHandler tests the connection to Spoolman


### PR DESCRIPTION
refactor: remove printer model field and hostname detection since the model is not used anywhere functionally, and is only for display purposes. This is a simple refactor to help streamline and cut as much bloat and scope creep as possible.