### PR TITLE
feat: add Apprise push notification support with stateful/stateless modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Spoolman is an excellent tool to track one's filament inventory. However, manual
 - **Quick-Assign Tags**: Single-printer setups get one-scan tags that assign a spool straight to the printer, no location tag needed
 - **Location Tracking**: Track spools in custom locations (dryboxes) or printer toolheads
 - **Smart Housekeeping**: If a new spool is "loaded" to a printer, the previous will be returned to a pre-set default location
+- **Push Notifications**: Get notified via Discord, Telegram, Slack, email, and [90+ other services](https://appriseit.com/services/) when prints start, finish, fail, or when filament runs low — powered by [Apprise](https://github.com/caronc/apprise)
 
 ## Why FilaBridge?
 
@@ -224,6 +225,37 @@ The web interface provides:
 
 If you have exactly one printer with one toolhead configured, the Spool Tags screen also offers a Quick-Assign variant for each spool: a single tag that assigns the spool directly to your printer in one scan, with no location tag needed. Multi-toolhead users can build the same thing manually by appending `&location=<location name>` to a spool URL.
 
+### Push Notifications (Apprise)
+
+FilaBridge can send push notifications to Discord, Telegram, Slack, email, and [90+ other services](https://appriseit.com/services/) via [Apprise](https://github.com/caronc/apprise).
+
+**Setup:**
+
+1. **Run the Apprise API sidecar** alongside FilaBridge. If you use docker-compose, uncomment the `apprise` service in `docker-compose.yml`. Otherwise:
+   ```bash
+   docker run -d --name apprise -p 8000:8000 caronc/apprise:latest
+   ```
+
+2. **Configure in FilaBridge**: Go to Settings > Notifications and:
+   - Enable notifications
+   - Set the **Apprise API URL** (e.g. `http://apprise:8000` if using docker-compose, or `http://localhost:8000` if running standalone)
+   - Choose a **Notification Mode**:
+     - **Stateless** — notification URLs are sent with each request. Add one or more [Apprise URLs](https://appriseit.com/services/) for your services, one per line. Examples:
+       - Discord: `discord://webhook_id/webhook_token`
+       - Telegram: `tgram://bot_token/chat_id`
+       - Slack: `slack://token_a/token_b/token_c/#channel`
+       - Email: `mailto://user:pass@gmail.com`
+     - **Stateful** — notification URLs are configured and stored in the Apprise API itself (via its web UI or config). Set the **Persistent Storage Key** and optionally a **Tag** to target specific services. This is the recommended mode when running Apprise API as a shared notification hub.
+   - Use the **Test** button to verify the connection
+   - Choose which events trigger notifications:
+     - Print started
+     - Print completed
+     - Print failed/cancelled
+     - Low filament warning
+     - Print auto-paused (due to insufficient filament)
+     - Printer went offline
+     - Printer came back online
+
 ## API Endpoints
 
 The web interface also provides REST API endpoints:
@@ -242,6 +274,9 @@ The web interface also provides REST API endpoints:
 - `GET /api/nfc/urls` - Get all NFC URLs with QR codes
 - `GET /api/nfc/session/status` - Check NFC session status
 - `GET/POST /api/locations`, `PUT/DELETE /api/locations/{name}` - Manage locations
+- `GET/PUT /api/config/notifications` - Read and update notification settings
+- `POST /api/config/notifications/test-connection` - Test Apprise API connectivity
+- `POST /api/config/notifications/test` - Send a test notification
 - `WS /ws/status` - WebSocket endpoint for real-time status updates
 
 ## Project Structure
@@ -255,6 +290,7 @@ filabridge/
 ├── prusalink.go           # PrusaLink API client
 ├── spoolman.go            # Spoolman API client
 ├── bridge.go              # Core monitoring and usage tracking logic
+├── notifier.go            # Apprise push notification client
 ├── nfc.go                 # NFC session management and tag handling
 ├── web.go                 # HTTP server and API routes
 ├── templates/             # HTML templates

--- a/bridge.go
+++ b/bridge.go
@@ -35,6 +35,7 @@ type FilamentBridge struct {
 	warnMutex        sync.RWMutex             // Guards runoutWarnings and runoutChecked
 	errorMutex       sync.RWMutex
 	mutex            sync.RWMutex
+	notifier         *AppriseNotifier
 }
 
 // ToolheadMapping represents a mapping between a printer toolhead and a spool
@@ -114,6 +115,7 @@ func NewFilamentBridge(config *Config) (*FilamentBridge, error) {
 		scanInFlight:     make(map[string]bool),
 		runoutWarnings:   make(map[string]RunoutWarning),
 		runoutChecked:    make(map[string]int),
+		notifier:         NewAppriseNotifier(AppriseTimeout),
 	}
 
 	// Initialize database
@@ -289,6 +291,16 @@ func (b *FilamentBridge) initializeDefaultConfig() error {
 		ConfigKeyPrintHistoryEnabled:             "true",  // Keep a local record of prints for the history tab
 		ConfigKeyRunoutWarningEnabled:            "true",  // Warn when the mapped spool has less filament than the print needs
 		ConfigKeyRunoutPauseEnabled:              "false", // Also pause the print when a low-filament warning fires
+		ConfigKeyAppriseEnabled:                  "false",
+		ConfigKeyAppriseAPIURL:                   "",
+		ConfigKeyAppriseURLs:                     "",
+		ConfigKeyAppriseNotifyPrintStarted:       "true",
+		ConfigKeyAppriseNotifyPrintDone:          "true",
+		ConfigKeyAppriseNotifyPrintFailed:        "true",
+		ConfigKeyAppriseNotifyLowFilament:        "true",
+		ConfigKeyAppriseNotifyAutoPaused:         "true",
+		ConfigKeyAppriseNotifyOffline:            "true",
+		ConfigKeyAppriseNotifyOnline:             "true",
 	}
 
 	// Check if this is a fresh installation by checking if any config exists
@@ -623,6 +635,12 @@ func (b *FilamentBridge) checkRunoutWarnings(printerID string, config PrinterCon
 
 		log.Printf("Low filament warning for %s toolhead %d: spool %d (%s) has %.1fg remaining, print needs ~%.1fg",
 			printerName, toolheadID, spoolID, spool.Name, spool.RemainingWeight, needed)
+
+		if autoPaused {
+			go b.notifyAutoPaused(config, warning, aj)
+		} else {
+			go b.notifyLowFilament(config, warning, aj)
+		}
 	}
 }
 
@@ -1269,12 +1287,16 @@ func (b *FilamentBridge) noteConnectivity(printerID, ipAddress, name string, err
 			log.Printf("Printer %s (%s - %s) is offline, suppressing further offline warnings until it returns: %v",
 				ipAddress, printerID, name, err)
 			b.offlinePrinters[printerID] = true
+			title, body, notifType := buildOfflineMessage(name, ipAddress)
+			go b.notify(ConfigKeyAppriseNotifyOffline, title, body, notifType)
 		}
 		return
 	}
 	if wasOffline {
 		log.Printf("Printer %s (%s - %s) is back online", ipAddress, printerID, name)
 		delete(b.offlinePrinters, printerID)
+		title, body, notifType := buildOnlineMessage(name, ipAddress)
+		go b.notify(ConfigKeyAppriseNotifyOnline, title, body, notifType)
 	}
 }
 
@@ -1454,6 +1476,10 @@ func (b *FilamentBridge) monitorPrusaLink(printerID string, config PrinterConfig
 			}
 		}
 
+		if active == nil && aj.Filename != "" {
+			go b.notifyPrintStarted(config, aj)
+		}
+
 		// With the estimate in hand, warn (and optionally pause) if the mapped
 		// spool has less filament remaining than the print still needs.
 		b.checkRunoutWarnings(printerID, config, client, aj)
@@ -1510,6 +1536,8 @@ func (b *FilamentBridge) monitorPrusaLink(printerID string, config PrinterConfig
 			b.clearActiveJob(printerID)
 			return nil
 		}
+
+		go b.notifyPrintEnded(config, active, completed, usageScale)
 
 		// Success: record in the idempotency ledger, then clear tracking.
 		if err := b.markJobRecorded(printerID, active.JobID, active.Filename, usageScale); err != nil {

--- a/constants.go
+++ b/constants.go
@@ -46,6 +46,19 @@ const (
 	ConfigKeyPrintHistoryEnabled             = "print_history_enabled"
 	ConfigKeyRunoutWarningEnabled            = "runout_warning_enabled"
 	ConfigKeyRunoutPauseEnabled              = "runout_pause_enabled"
+	ConfigKeyAppriseEnabled                  = "apprise_enabled"
+	ConfigKeyAppriseAPIURL                   = "apprise_api_url"
+	ConfigKeyAppriseMode                     = "apprise_mode"
+	ConfigKeyAppriseURLs                     = "apprise_urls"
+	ConfigKeyAppriseKey                      = "apprise_key"
+	ConfigKeyAppriseTag                      = "apprise_tag"
+	ConfigKeyAppriseNotifyPrintStarted       = "apprise_notify_print_started"
+	ConfigKeyAppriseNotifyPrintDone          = "apprise_notify_print_done"
+	ConfigKeyAppriseNotifyPrintFailed        = "apprise_notify_print_failed"
+	ConfigKeyAppriseNotifyLowFilament        = "apprise_notify_low_filament"
+	ConfigKeyAppriseNotifyAutoPaused         = "apprise_notify_auto_paused"
+	ConfigKeyAppriseNotifyOffline            = "apprise_notify_offline"
+	ConfigKeyAppriseNotifyOnline             = "apprise_notify_online"
 )
 
 // HTTP timeouts
@@ -53,4 +66,5 @@ const (
 	PrusaLinkTimeout             = 10  // seconds
 	PrusaLinkFileDownloadTimeout = 300 // seconds for file downloads (USB storage can be slow)
 	SpoolmanTimeout              = 10  // seconds
+	AppriseTimeout               = 30  // seconds
 )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,12 @@ services:
       timeout: 5s
       start_period: 10s
       retries: 3
+
+  # Optional: Apprise API for push notifications (Discord, Telegram, Slack, email, etc.)
+  # Uncomment to enable, then configure in FilaBridge Settings > Notifications
+  # with API URL: http://apprise:8000
+  # apprise:
+  #   image: caronc/apprise:latest
+  #   ports:
+  #     - "8000:8000"
+  #   restart: unless-stopped

--- a/notifier.go
+++ b/notifier.go
@@ -1,0 +1,342 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type AppriseNotifier struct {
+	httpClient *http.Client
+}
+
+func NewAppriseNotifier(timeoutSeconds int) *AppriseNotifier {
+	return &AppriseNotifier{
+		httpClient: &http.Client{
+			Timeout: time.Duration(timeoutSeconds) * time.Second,
+		},
+	}
+}
+
+type appriseStatelessRequest struct {
+	URLs  []string `json:"urls"`
+	Title string   `json:"title"`
+	Body  string   `json:"body"`
+	Type  string   `json:"type"`
+}
+
+type appriseStatefulRequest struct {
+	Tag   string `json:"tag"`
+	Title string `json:"title"`
+	Body  string `json:"body"`
+	Type  string `json:"type"`
+}
+
+func (n *AppriseNotifier) Send(apiURL string, urls []string, title, body, notifType string) error {
+	endpoint := strings.TrimRight(apiURL, "/") + "/notify/"
+
+	payload := appriseStatelessRequest{
+		URLs:  urls,
+		Title: title,
+		Body:  body,
+		Type:  notifType,
+	}
+	jsonBody, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal notification: %w", err)
+	}
+
+	resp, err := n.httpClient.Post(endpoint, "application/json", bytes.NewReader(jsonBody))
+	if err != nil {
+		return fmt.Errorf("failed to send notification: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("apprise API returned status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func (n *AppriseNotifier) SendStateful(apiURL, key, tag, title, body, notifType string) error {
+	endpoint := strings.TrimRight(apiURL, "/") + "/notify/" + key
+
+	payload := appriseStatefulRequest{
+		Tag:   tag,
+		Title: title,
+		Body:  body,
+		Type:  notifType,
+	}
+	jsonBody, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal notification: %w", err)
+	}
+
+	resp, err := n.httpClient.Post(endpoint, "application/json", bytes.NewReader(jsonBody))
+	if err != nil {
+		return fmt.Errorf("failed to send notification: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("apprise API returned status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func (n *AppriseNotifier) TestConnection(apiURL string) error {
+	endpoint := strings.TrimRight(apiURL, "/") + "/status"
+
+	resp, err := n.httpClient.Get(endpoint)
+	if err != nil {
+		return fmt.Errorf("failed to connect to Apprise API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("apprise API returned status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// notify fires an asynchronous notification if Apprise is enabled and the
+// specific event toggle is on. Failures are logged but never block the caller.
+func (b *FilamentBridge) notify(eventKey, title, body, notifType string) {
+	enabled, err := b.GetConfigValue(ConfigKeyAppriseEnabled)
+	if err != nil || enabled != "true" {
+		return
+	}
+
+	eventEnabled, err := b.GetConfigValue(eventKey)
+	if err != nil || eventEnabled == "false" {
+		return
+	}
+
+	apiURL, err := b.GetConfigValue(ConfigKeyAppriseAPIURL)
+	if err != nil || apiURL == "" {
+		return
+	}
+
+	mode, _ := b.GetConfigValue(ConfigKeyAppriseMode)
+
+	if mode == "stateful" {
+		key, _ := b.GetConfigValue(ConfigKeyAppriseKey)
+		tag, _ := b.GetConfigValue(ConfigKeyAppriseTag)
+		if key == "" {
+			return
+		}
+		go func() {
+			if err := b.notifier.SendStateful(apiURL, key, tag, title, body, notifType); err != nil {
+				log.Printf("Warning: failed to send %s notification: %v", eventKey, err)
+			}
+		}()
+		return
+	}
+
+	rawURLs, err := b.GetConfigValue(ConfigKeyAppriseURLs)
+	if err != nil || rawURLs == "" {
+		return
+	}
+
+	var urls []string
+	for _, u := range strings.Split(rawURLs, "\n") {
+		u = strings.TrimSpace(u)
+		if u != "" {
+			urls = append(urls, u)
+		}
+	}
+	if len(urls) == 0 {
+		return
+	}
+
+	go func() {
+		if err := b.notifier.Send(apiURL, urls, title, body, notifType); err != nil {
+			log.Printf("Warning: failed to send %s notification: %v", eventKey, err)
+		}
+	}()
+}
+
+// toolheadNotifyInfo holds resolved spool data for a single toolhead,
+// used by the message builders so they don't need DB access.
+type toolheadNotifyInfo struct {
+	ID              int
+	SpoolID         int
+	SpoolName       string
+	Brand           string
+	Material        string
+	EstimateGrams   float64
+	UsedGrams       float64
+	RemainingWeight float64
+	Mapped          bool
+	Resolved        bool
+}
+
+func buildPrintStartedMessage(printerName, filename string, toolheads []toolheadNotifyInfo) (title, body, notifType string) {
+	var b strings.Builder
+	fmt.Fprintf(&b, "File: %s\n", filename)
+
+	for _, th := range toolheads {
+		if !th.Mapped {
+			fmt.Fprintf(&b, "\nToolhead %d: No spool mapped\n  Estimated usage: %.1fg\n", th.ID, th.EstimateGrams)
+		} else if !th.Resolved {
+			fmt.Fprintf(&b, "\nToolhead %d: Spool %d (could not fetch details)\n  Estimated usage: %.1fg\n", th.ID, th.SpoolID, th.EstimateGrams)
+		} else {
+			fmt.Fprintf(&b, "\nToolhead %d: %s (%s %s)\n", th.ID, th.SpoolName, th.Brand, th.Material)
+			fmt.Fprintf(&b, "  Estimated usage: %.1fg\n", th.EstimateGrams)
+			fmt.Fprintf(&b, "  Remaining on spool: %.1fg\n", th.RemainingWeight)
+			if th.EstimateGrams > th.RemainingWeight {
+				fmt.Fprintf(&b, "  WARNING: Estimate exceeds remaining by %.1fg\n", th.EstimateGrams-th.RemainingWeight)
+			}
+		}
+	}
+
+	return fmt.Sprintf("Print Started on %s", printerName), b.String(), "info"
+}
+
+func buildPrintEndedMessage(printerName, filename, durationStr string, completed bool, usageScale float64, toolheads []toolheadNotifyInfo) (title, body, notifType string) {
+	var t string
+	if completed {
+		t = fmt.Sprintf("Print Completed on %s", printerName)
+		notifType = "success"
+	} else {
+		t = fmt.Sprintf("Print Failed on %s", printerName)
+		notifType = "failure"
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "File: %s\n", filename)
+	if !completed {
+		fmt.Fprintf(&b, "Progress: ~%.0f%%\n", usageScale*100)
+	}
+	fmt.Fprintf(&b, "Duration: %s\n", durationStr)
+
+	for _, th := range toolheads {
+		if !th.Mapped {
+			fmt.Fprintf(&b, "\nToolhead %d: No spool mapped\n  Used: %.1fg\n", th.ID, th.UsedGrams)
+		} else if !th.Resolved {
+			fmt.Fprintf(&b, "\nToolhead %d: Spool %d\n  Used: %.1fg\n", th.ID, th.SpoolID, th.UsedGrams)
+		} else {
+			fmt.Fprintf(&b, "\nToolhead %d: %s (%s %s)\n", th.ID, th.SpoolName, th.Brand, th.Material)
+			fmt.Fprintf(&b, "  Used: %.1fg\n", th.UsedGrams)
+			fmt.Fprintf(&b, "  Remaining: %.1fg\n", th.RemainingWeight)
+		}
+	}
+
+	return t, b.String(), notifType
+}
+
+func buildLowFilamentMessage(printerName, filename, spoolName string, spoolID int, remainingWeight, requiredWeight float64) (title, body, notifType string) {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Spool \"%s\" (ID: %d) is running low.\n", spoolName, spoolID)
+	fmt.Fprintf(&b, "Remaining: %.1fg\n", remainingWeight)
+	fmt.Fprintf(&b, "Print needs: ~%.1fg\n", requiredWeight)
+	fmt.Fprintf(&b, "Shortage: %.1fg\n", requiredWeight-remainingWeight)
+	fmt.Fprintf(&b, "\nPrint at risk: %s on %s", filename, printerName)
+
+	return fmt.Sprintf("Low Filament Warning: %s", printerName), b.String(), "warning"
+}
+
+func buildAutoPausedMessage(printerName, spoolName string, spoolID, toolheadID int, remainingWeight, requiredWeight float64) (title, body, notifType string) {
+	var b strings.Builder
+	fmt.Fprintf(&b, "The print has been paused due to low filament.\n\n")
+	fmt.Fprintf(&b, "Spool \"%s\" (ID: %d) has %.1fg remaining.\n", spoolName, spoolID, remainingWeight)
+	fmt.Fprintf(&b, "The print needs ~%.1fg to finish.\n\n", requiredWeight)
+	fmt.Fprintf(&b, "To resume:\n")
+	fmt.Fprintf(&b, "1. Swap the spool on Toolhead %d and remap it in FilaBridge\n", toolheadID)
+	fmt.Fprintf(&b, "2. Acknowledge the warning on the FilaBridge dashboard (this resumes the print)\n")
+	fmt.Fprintf(&b, "   OR resume directly from the printer")
+
+	return fmt.Sprintf("Print Paused — Filament Insufficient: %s", printerName), b.String(), "warning"
+}
+
+func buildOfflineMessage(printerName, ipAddress string) (title, body, notifType string) {
+	return fmt.Sprintf("Printer Offline: %s", printerName),
+		fmt.Sprintf("Printer %s (%s) is no longer reachable.", printerName, ipAddress),
+		"failure"
+}
+
+func buildOnlineMessage(printerName, ipAddress string) (title, body, notifType string) {
+	return fmt.Sprintf("Printer Online: %s", printerName),
+		fmt.Sprintf("Printer %s (%s) is back online.", printerName, ipAddress),
+		"success"
+}
+
+// resolveToolheads fetches spool data for each toolhead in a job's usage map.
+func (b *FilamentBridge) resolveToolheads(printerName string, usage map[int]float64, usageScale float64) []toolheadNotifyInfo {
+	var toolheads []toolheadNotifyInfo
+	for toolheadID, estimateGrams := range usage {
+		th := toolheadNotifyInfo{
+			ID:            toolheadID,
+			EstimateGrams: estimateGrams,
+			UsedGrams:     estimateGrams * usageScale,
+		}
+		spoolID, err := b.GetToolheadMapping(printerName, toolheadID)
+		if err != nil || spoolID == 0 {
+			toolheads = append(toolheads, th)
+			continue
+		}
+		th.SpoolID = spoolID
+		th.Mapped = true
+		spool, err := b.spoolman.GetSpool(spoolID)
+		if err != nil {
+			toolheads = append(toolheads, th)
+			continue
+		}
+		th.Resolved = true
+		th.SpoolName = spool.Name
+		th.Brand = spool.Brand
+		th.Material = spool.Material
+		th.RemainingWeight = spool.RemainingWeight
+		toolheads = append(toolheads, th)
+	}
+	return toolheads
+}
+
+func (b *FilamentBridge) notifyPrintStarted(config PrinterConfig, aj *activeJob) {
+	printerName := resolvePrinterName(config)
+	toolheads := b.resolveToolheads(printerName, aj.Usage, 1.0)
+	title, body, notifType := buildPrintStartedMessage(printerName, aj.Filename, toolheads)
+	b.notify(ConfigKeyAppriseNotifyPrintStarted, title, body, notifType)
+}
+
+func (b *FilamentBridge) notifyPrintEnded(config PrinterConfig, active *activeJob, completed bool, usageScale float64) {
+	printerName := resolvePrinterName(config)
+	durationStr := formatDuration(time.Since(active.StartedAt))
+	toolheads := b.resolveToolheads(printerName, active.Usage, usageScale)
+
+	var eventKey string
+	if completed {
+		eventKey = ConfigKeyAppriseNotifyPrintDone
+	} else {
+		eventKey = ConfigKeyAppriseNotifyPrintFailed
+	}
+
+	title, body, notifType := buildPrintEndedMessage(printerName, active.Filename, durationStr, completed, usageScale, toolheads)
+	b.notify(eventKey, title, body, notifType)
+}
+
+func (b *FilamentBridge) notifyLowFilament(config PrinterConfig, warning RunoutWarning, aj *activeJob) {
+	title, body, notifType := buildLowFilamentMessage(warning.PrinterName, aj.Filename, warning.SpoolName, warning.SpoolID, warning.RemainingWeight, warning.RequiredWeight)
+	b.notify(ConfigKeyAppriseNotifyLowFilament, title, body, notifType)
+}
+
+func (b *FilamentBridge) notifyAutoPaused(config PrinterConfig, warning RunoutWarning, aj *activeJob) {
+	title, body, notifType := buildAutoPausedMessage(warning.PrinterName, warning.SpoolName, warning.SpoolID, warning.ToolheadID, warning.RemainingWeight, warning.RequiredWeight)
+	b.notify(ConfigKeyAppriseNotifyAutoPaused, title, body, notifType)
+}
+
+func formatDuration(d time.Duration) string {
+	hours := int(d.Hours())
+	minutes := int(d.Minutes()) % 60
+	if hours > 0 {
+		return fmt.Sprintf("%dh %dm", hours, minutes)
+	}
+	if minutes > 0 {
+		return fmt.Sprintf("%dm", minutes)
+	}
+	return fmt.Sprintf("%ds", int(d.Seconds()))
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -40,6 +40,8 @@ function switchTab(tabName) {
                     loadConfiguration();
                 } else if (tabId === 'printers') {
                     loadPrinters();
+                } else if (tabId === 'notifications') {
+                    loadNotificationSettings();
                 } else if (tabId === 'advanced') {
                     loadAdvancedSettings();
                     loadAutoAssignSettings();
@@ -178,6 +180,8 @@ function switchSettingsTab(tabName, clickedElement) {
         loadConfiguration();
     } else if (tabName === 'printers') {
         loadPrinters();
+    } else if (tabName === 'notifications') {
+        loadNotificationSettings();
     } else if (tabName === 'advanced') {
         loadAdvancedSettings();
         loadAutoAssignSettings();
@@ -528,6 +532,220 @@ function clearPrintHistory() {
     })
     .catch(error => {
         alert('Error clearing history: ' + error.message);
+    });
+}
+
+// Notification Settings Functions
+let appriseCheckboxHandler = null;
+
+let _savedAppriseApiUrl = '';
+let _savedAppriseUrls = '';
+let _savedAppriseMode = 'stateless';
+let _savedAppriseKey = '';
+let _savedAppriseTag = '';
+
+function _checkNotificationFieldsChanged() {
+    const apiUrl = document.getElementById('appriseApiUrl')?.value || '';
+    const urls = document.getElementById('appriseUrls')?.value || '';
+    const mode = document.querySelector('input[name="appriseMode"]:checked')?.value || 'stateless';
+    const key = document.getElementById('appriseKey')?.value || '';
+    const tag = document.getElementById('appriseTag')?.value || '';
+    const changed = apiUrl !== _savedAppriseApiUrl || urls !== _savedAppriseUrls ||
+        mode !== _savedAppriseMode || key !== _savedAppriseKey || tag !== _savedAppriseTag;
+    document.querySelectorAll('.test-event-btn').forEach(btn => {
+        btn.style.display = changed ? 'none' : '';
+    });
+    if (changed) {
+        document.getElementById('notificationSaveResult').innerHTML = '';
+    }
+}
+
+function _updateModeFields() {
+    const mode = document.querySelector('input[name="appriseMode"]:checked')?.value || 'stateless';
+    document.getElementById('statelessFields').style.display = mode === 'stateless' ? 'block' : 'none';
+    document.getElementById('statefulFields').style.display = mode === 'stateful' ? 'block' : 'none';
+}
+
+function _onModeChange() {
+    _updateModeFields();
+    _checkNotificationFieldsChanged();
+}
+
+function loadNotificationSettings() {
+    fetch('/api/config/notifications')
+        .then(response => response.json())
+        .then(data => {
+            if (data.error) {
+                console.error('Error loading notification settings:', data.error);
+                return;
+            }
+
+            document.getElementById('appriseEnabled').checked = data.enabled || false;
+            document.getElementById('appriseApiUrl').value = data.api_url || '';
+            document.getElementById('appriseUrls').value = data.urls || '';
+            document.getElementById('appriseKey').value = data.key || '';
+            document.getElementById('appriseTag').value = data.tag || '';
+
+            const mode = data.mode || 'stateless';
+            document.getElementById('appriseModeStateless').checked = mode === 'stateless';
+            document.getElementById('appriseModeStateful').checked = mode === 'stateful';
+            _updateModeFields();
+
+            _savedAppriseApiUrl = data.api_url || '';
+            _savedAppriseUrls = data.urls || '';
+            _savedAppriseMode = mode;
+            _savedAppriseKey = data.key || '';
+            _savedAppriseTag = data.tag || '';
+
+            document.getElementById('notifyPrintStarted').checked = data.notify_print_started !== false;
+            document.getElementById('notifyPrintDone').checked = data.notify_print_done !== false;
+            document.getElementById('notifyPrintFailed').checked = data.notify_print_failed !== false;
+            document.getElementById('notifyLowFilament').checked = data.notify_low_filament !== false;
+            document.getElementById('notifyAutoPaused').checked = data.notify_auto_paused !== false;
+            document.getElementById('notifyOffline').checked = data.notify_offline !== false;
+            document.getElementById('notifyOnline').checked = data.notify_online !== false;
+
+            const settingsGroup = document.getElementById('appriseSettingsGroup');
+            settingsGroup.style.display = data.enabled ? 'block' : 'none';
+
+            const checkbox = document.getElementById('appriseEnabled');
+            if (appriseCheckboxHandler) {
+                checkbox.removeEventListener('change', appriseCheckboxHandler);
+            }
+            appriseCheckboxHandler = function() {
+                settingsGroup.style.display = this.checked ? 'block' : 'none';
+            };
+            checkbox.addEventListener('change', appriseCheckboxHandler);
+
+            document.getElementById('appriseConnectionResult').innerHTML = '';
+            document.getElementById('notificationSaveResult').innerHTML = '';
+
+            const apiUrlInput = document.getElementById('appriseApiUrl');
+            const urlsInput = document.getElementById('appriseUrls');
+            const keyInput = document.getElementById('appriseKey');
+            const tagInput = document.getElementById('appriseTag');
+            const modeRadios = document.querySelectorAll('input[name="appriseMode"]');
+
+            [apiUrlInput, urlsInput, keyInput, tagInput].forEach(el => {
+                el.removeEventListener('input', _checkNotificationFieldsChanged);
+                el.addEventListener('input', _checkNotificationFieldsChanged);
+            });
+            modeRadios.forEach(r => {
+                r.removeEventListener('change', _onModeChange);
+                r.addEventListener('change', _onModeChange);
+            });
+
+            _checkNotificationFieldsChanged();
+        })
+        .catch(error => {
+            console.error('Error loading notification settings:', error);
+        });
+}
+
+function saveNotificationSettings() {
+    const enabled = document.getElementById('appriseEnabled').checked;
+    const apiUrl = document.getElementById('appriseApiUrl').value.trim();
+
+    const resultDiv = document.getElementById('notificationSaveResult');
+
+    if (enabled && !apiUrl) {
+        resultDiv.innerHTML = '<span style="color: #f44336;">❌ Apprise API URL is required when notifications are enabled.</span>';
+        return;
+    }
+
+    resultDiv.innerHTML = '<span style="color: #aaa;">Saving...</span>';
+
+    const mode = document.querySelector('input[name="appriseMode"]:checked')?.value || 'stateless';
+    const key = document.getElementById('appriseKey').value.trim() || 'apprise';
+    const tag = document.getElementById('appriseTag').value.trim() || 'all';
+
+    if (mode === 'stateful') {
+        document.getElementById('appriseKey').value = key;
+        document.getElementById('appriseTag').value = tag;
+    }
+
+    const settings = {
+        enabled: enabled,
+        api_url: apiUrl,
+        mode: mode,
+        urls: document.getElementById('appriseUrls').value,
+        key: key,
+        tag: tag,
+        notify_print_started: document.getElementById('notifyPrintStarted').checked,
+        notify_print_done: document.getElementById('notifyPrintDone').checked,
+        notify_print_failed: document.getElementById('notifyPrintFailed').checked,
+        notify_low_filament: document.getElementById('notifyLowFilament').checked,
+        notify_auto_paused: document.getElementById('notifyAutoPaused').checked,
+        notify_offline: document.getElementById('notifyOffline').checked,
+        notify_online: document.getElementById('notifyOnline').checked,
+    };
+
+    fetch('/api/config/notifications', {
+        method: 'PUT',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(settings)
+    })
+    .then(response => response.json())
+    .then(data => {
+        if (data.error) {
+            resultDiv.innerHTML = '<span style="color: #f44336;">❌ ' + escapeHtml(data.error) + '</span>';
+        } else {
+            resultDiv.innerHTML = '<span style="color: #4caf50;">✅ Settings saved</span>';
+            _savedAppriseApiUrl = document.getElementById('appriseApiUrl').value.trim();
+            _savedAppriseUrls = document.getElementById('appriseUrls').value;
+            _savedAppriseMode = document.querySelector('input[name="appriseMode"]:checked')?.value || 'stateless';
+            _savedAppriseKey = document.getElementById('appriseKey').value.trim();
+            _savedAppriseTag = document.getElementById('appriseTag').value.trim();
+            _checkNotificationFieldsChanged();
+        }
+    })
+    .catch(error => {
+        resultDiv.innerHTML = '<span style="color: #f44336;">❌ ' + escapeHtml(error.message) + '</span>';
+    });
+}
+
+function testAppriseConnection() {
+    const resultDiv = document.getElementById('appriseConnectionResult');
+    resultDiv.innerHTML = '<span style="color: #aaa;">Testing connection...</span>';
+
+    const apiURL = document.getElementById('appriseApiUrl')?.value || '';
+    fetch('/api/config/notifications/test-connection', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({ api_url: apiURL })
+    })
+    .then(response => response.json())
+    .then(data => {
+        if (data.connected) {
+            resultDiv.innerHTML = '<span style="color: #4caf50;">✅ Connection successful</span>';
+        } else {
+            resultDiv.innerHTML = '<span style="color: #f44336;">❌ ' + escapeHtml(data.error) + '</span>';
+        }
+    })
+    .catch(error => {
+        resultDiv.innerHTML = '<span style="color: #f44336;">❌ Connection failed: ' + escapeHtml(error.message) + '</span>';
+    });
+}
+
+function testEventNotification(event) {
+    const resultDiv = document.getElementById('notificationSaveResult');
+    resultDiv.innerHTML = '<span style="color: #aaa;">Sending test notification...</span>';
+
+    fetch('/api/config/notifications/test', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({ event: event })
+    })
+    .then(response => response.json())
+    .then(data => {
+        if (data.error) {
+            resultDiv.innerHTML = '<span style="color: #f44336;">❌ ' + escapeHtml(data.error) + '</span>';
+        } else {
+            resultDiv.innerHTML = '<span style="color: #4caf50;">✅ Test notification sent</span>';
+        }
+    })
+    .catch(error => {
+        resultDiv.innerHTML = '<span style="color: #f44336;">❌ ' + escapeHtml(error.message) + '</span>';
     });
 }
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -10,6 +10,7 @@
         <button class="settings-tab active" onclick="switchSettingsTab('getting-started', this)">📚 Getting Started</button>
         <button class="settings-tab" onclick="switchSettingsTab('basic-config', this)">🔧 Basic Configuration</button>
         <button class="settings-tab" onclick="switchSettingsTab('printers', this)">🖨️ Printers</button>
+        <button class="settings-tab" onclick="switchSettingsTab('notifications', this)">🔔 Notifications</button>
         <button class="settings-tab" onclick="switchSettingsTab('advanced', this)">⚙️ Advanced Settings</button>
     </div>
     
@@ -49,6 +50,144 @@
         </div>
     </div>
     
+    <!-- Notifications Tab -->
+    <div id="notifications-tab" class="settings-tab-content">
+        <div class="config-section">
+            <h3>🔔 Notification Settings</h3>
+            <div class="help-text">
+                Send push notifications via <a href="https://github.com/caronc/apprise" target="_blank" rel="noopener">Apprise</a> when prints start, finish, fail, or when printers go offline.
+                Requires an <a href="https://github.com/caronc/apprise-api" target="_blank" rel="noopener">Apprise API</a> container running alongside FilaBridge.
+            </div>
+
+            <div class="form-group">
+                <label style="display: flex; align-items: center; gap: 10px; cursor: pointer;">
+                    <input type="checkbox" id="appriseEnabled" style="width: auto; cursor: pointer;">
+                    <span><strong>Enable Notifications</strong></span>
+                </label>
+            </div>
+
+            <div id="appriseSettingsGroup" style="display: none;">
+                <div class="form-group">
+                    <label for="appriseApiUrl"><strong>Apprise API URL</strong></label>
+                    <div style="display: flex; gap: 10px; align-items: center;">
+                        <input type="text" id="appriseApiUrl" placeholder="http://apprise:8000" style="flex: 1;">
+                        <button class="btn btn-secondary" onclick="testAppriseConnection()" style="white-space: nowrap;">🔗 Test Connection</button>
+                    </div>
+                    <small>URL of the Apprise API container (required when notifications are enabled)</small>
+                    <div id="appriseConnectionResult" style="margin-top: 5px;"></div>
+                </div>
+
+                <div class="form-group">
+                    <label><strong>Notification Mode</strong></label>
+                    <div style="display: flex; gap: 20px; margin-top: 5px;">
+                        <label style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
+                            <input type="radio" name="appriseMode" value="stateless" id="appriseModeStateless" style="width: auto; cursor: pointer;">
+                            <span>Stateless — notification URLs sent with each request</span>
+                        </label>
+                        <label style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
+                            <input type="radio" name="appriseMode" value="stateful" id="appriseModeStateful" style="width: auto; cursor: pointer;">
+                            <span>Stateful — use persistent storage in Apprise API</span>
+                        </label>
+                    </div>
+                </div>
+
+                <div id="statelessFields">
+                    <div class="form-group">
+                        <label for="appriseUrls"><strong>Notification URLs</strong></label>
+                        <textarea id="appriseUrls" rows="4" style="width: 100%; padding: 12px; border-radius: 8px; border: 1px solid #666; font-size: 14px; background: rgba(255,255,255,0.1); color: #fff; font-family: monospace; resize: vertical;"></textarea>
+                        <small>One URL per line. <a href="https://appriseit.com/services/" target="_blank" rel="noopener">Supported services</a></small>
+                    </div>
+                </div>
+
+                <div id="statefulFields" style="display: none;">
+                    <div class="form-group">
+                        <label for="appriseKey"><strong>Persistent Storage Key</strong></label>
+                        <input type="text" id="appriseKey" placeholder="apprise">
+                        <small>The key used to store notification URLs in the Apprise API (configured in the Apprise web UI)</small>
+                    </div>
+                    <div class="form-group">
+                        <label for="appriseTag"><strong>Tag</strong></label>
+                        <input type="text" id="appriseTag" placeholder="all">
+                        <small>Only notify services matching this tag (leave empty to notify all configured services)</small>
+                    </div>
+                </div>
+
+                <div style="margin-top: 20px;">
+                    <label><strong>Event Toggles</strong></label>
+                    <small style="display: block; margin-bottom: 10px;">Choose which events trigger notifications</small>
+                    <div class="form-group">
+                        <div style="display: flex; align-items: center; gap: 10px;">
+                            <label style="display: flex; align-items: center; gap: 10px; cursor: pointer; flex: 1;">
+                                <input type="checkbox" id="notifyPrintStarted" style="width: auto; cursor: pointer;">
+                                <span>Print started</span>
+                            </label>
+                            <button class="btn btn-secondary test-event-btn" onclick="testEventNotification('print_started')" style="padding: 2px 8px; font-size: 12px;">Test</button>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div style="display: flex; align-items: center; gap: 10px;">
+                            <label style="display: flex; align-items: center; gap: 10px; cursor: pointer; flex: 1;">
+                                <input type="checkbox" id="notifyPrintDone" style="width: auto; cursor: pointer;">
+                                <span>Print completed</span>
+                            </label>
+                            <button class="btn btn-secondary test-event-btn" onclick="testEventNotification('print_done')" style="padding: 2px 8px; font-size: 12px;">Test</button>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div style="display: flex; align-items: center; gap: 10px;">
+                            <label style="display: flex; align-items: center; gap: 10px; cursor: pointer; flex: 1;">
+                                <input type="checkbox" id="notifyPrintFailed" style="width: auto; cursor: pointer;">
+                                <span>Print failed / cancelled</span>
+                            </label>
+                            <button class="btn btn-secondary test-event-btn" onclick="testEventNotification('print_failed')" style="padding: 2px 8px; font-size: 12px;">Test</button>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div style="display: flex; align-items: center; gap: 10px;">
+                            <label style="display: flex; align-items: center; gap: 10px; cursor: pointer; flex: 1;">
+                                <input type="checkbox" id="notifyLowFilament" style="width: auto; cursor: pointer;">
+                                <span>Low filament warning</span>
+                            </label>
+                            <button class="btn btn-secondary test-event-btn" onclick="testEventNotification('low_filament')" style="padding: 2px 8px; font-size: 12px;">Test</button>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div style="display: flex; align-items: center; gap: 10px;">
+                            <label style="display: flex; align-items: center; gap: 10px; cursor: pointer; flex: 1;">
+                                <input type="checkbox" id="notifyAutoPaused" style="width: auto; cursor: pointer;">
+                                <span>Print auto-paused (low filament)</span>
+                            </label>
+                            <button class="btn btn-secondary test-event-btn" onclick="testEventNotification('auto_paused')" style="padding: 2px 8px; font-size: 12px;">Test</button>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div style="display: flex; align-items: center; gap: 10px;">
+                            <label style="display: flex; align-items: center; gap: 10px; cursor: pointer; flex: 1;">
+                                <input type="checkbox" id="notifyOffline" style="width: auto; cursor: pointer;">
+                                <span>Printer offline</span>
+                            </label>
+                            <button class="btn btn-secondary test-event-btn" onclick="testEventNotification('offline')" style="padding: 2px 8px; font-size: 12px;">Test</button>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div style="display: flex; align-items: center; gap: 10px;">
+                            <label style="display: flex; align-items: center; gap: 10px; cursor: pointer; flex: 1;">
+                                <input type="checkbox" id="notifyOnline" style="width: auto; cursor: pointer;">
+                                <span>Printer back online</span>
+                            </label>
+                            <button class="btn btn-secondary test-event-btn" onclick="testEventNotification('online')" style="padding: 2px 8px; font-size: 12px;">Test</button>
+                        </div>
+                    </div>
+                </div>
+
+                <div style="margin-top: 20px; text-align: center;">
+                    <button class="btn" onclick="saveNotificationSettings()">💾 Save Notification Settings</button>
+                    <div id="notificationSaveResult" style="margin-top: 10px;"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- Advanced Settings Tab -->
     <div id="advanced-tab" class="settings-tab-content">
         <div class="config-section">

--- a/web.go
+++ b/web.go
@@ -163,6 +163,10 @@ func (ws *WebServer) setupRoutes() {
 		api.PUT("/config/auto-assign-previous-spool", ws.updateAutoAssignPreviousSpoolHandler)
 		api.GET("/config/print-history", ws.getPrintHistorySettingHandler)
 		api.PUT("/config/print-history", ws.updatePrintHistorySettingHandler)
+		api.GET("/config/notifications", ws.getNotificationSettingsHandler)
+		api.PUT("/config/notifications", ws.updateNotificationSettingsHandler)
+		api.POST("/config/notifications/test-connection", ws.testAppriseConnectionHandler)
+		api.POST("/config/notifications/test", ws.testNotificationHandler)
 		api.GET("/printers", ws.getPrintersHandler)
 		api.POST("/printers", ws.addPrinterHandler)
 		api.PUT("/printers/:id", ws.updatePrinterHandler)
@@ -1159,6 +1163,213 @@ func (ws *WebServer) updatePrintHistorySettingHandler(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"message": "Print history setting updated", "enabled": req.Enabled})
+}
+
+func (ws *WebServer) getNotificationSettingsHandler(c *gin.Context) {
+	getBool := func(key string) bool {
+		val, err := ws.bridge.GetConfigValue(key)
+		if err != nil {
+			return true
+		}
+		return val != "false"
+	}
+	getString := func(key string) string {
+		val, _ := ws.bridge.GetConfigValue(key)
+		return val
+	}
+
+	urls := getString(ConfigKeyAppriseURLs)
+	mode := getString(ConfigKeyAppriseMode)
+	if mode == "" {
+		mode = "stateless"
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"enabled":              getString(ConfigKeyAppriseEnabled) == "true",
+		"api_url":              getString(ConfigKeyAppriseAPIURL),
+		"mode":                 mode,
+		"urls":                 urls,
+		"key":                  getString(ConfigKeyAppriseKey),
+		"tag":                  getString(ConfigKeyAppriseTag),
+		"notify_print_started": getBool(ConfigKeyAppriseNotifyPrintStarted),
+		"notify_print_done":    getBool(ConfigKeyAppriseNotifyPrintDone),
+		"notify_print_failed":  getBool(ConfigKeyAppriseNotifyPrintFailed),
+		"notify_low_filament":  getBool(ConfigKeyAppriseNotifyLowFilament),
+		"notify_auto_paused":   getBool(ConfigKeyAppriseNotifyAutoPaused),
+		"notify_offline":       getBool(ConfigKeyAppriseNotifyOffline),
+		"notify_online":        getBool(ConfigKeyAppriseNotifyOnline),
+	})
+}
+
+func (ws *WebServer) updateNotificationSettingsHandler(c *gin.Context) {
+	var req struct {
+		Enabled            bool   `json:"enabled"`
+		APIURL             string `json:"api_url"`
+		Mode               string `json:"mode"`
+		URLs               string `json:"urls"`
+		Key                string `json:"key"`
+		Tag                string `json:"tag"`
+		NotifyPrintStarted bool   `json:"notify_print_started"`
+		NotifyPrintDone    bool   `json:"notify_print_done"`
+		NotifyPrintFailed  bool   `json:"notify_print_failed"`
+		NotifyLowFilament  bool   `json:"notify_low_filament"`
+		NotifyAutoPaused   bool   `json:"notify_auto_paused"`
+		NotifyOffline      bool   `json:"notify_offline"`
+		NotifyOnline       bool   `json:"notify_online"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid JSON"})
+		return
+	}
+
+	if req.Enabled && req.APIURL == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Apprise API URL is required when notifications are enabled"})
+		return
+	}
+
+	if req.Mode == "" {
+		req.Mode = "stateless"
+	}
+
+	boolStr := func(v bool) string {
+		if v {
+			return "true"
+		}
+		return "false"
+	}
+
+	settings := map[string]string{
+		ConfigKeyAppriseEnabled:            boolStr(req.Enabled),
+		ConfigKeyAppriseAPIURL:             req.APIURL,
+		ConfigKeyAppriseMode:               req.Mode,
+		ConfigKeyAppriseKey:                req.Key,
+		ConfigKeyAppriseTag:                req.Tag,
+		ConfigKeyAppriseNotifyPrintStarted: boolStr(req.NotifyPrintStarted),
+		ConfigKeyAppriseNotifyPrintDone:    boolStr(req.NotifyPrintDone),
+		ConfigKeyAppriseNotifyPrintFailed:  boolStr(req.NotifyPrintFailed),
+		ConfigKeyAppriseNotifyLowFilament:  boolStr(req.NotifyLowFilament),
+		ConfigKeyAppriseNotifyAutoPaused:   boolStr(req.NotifyAutoPaused),
+		ConfigKeyAppriseNotifyOffline:      boolStr(req.NotifyOffline),
+		ConfigKeyAppriseNotifyOnline:       boolStr(req.NotifyOnline),
+	}
+	if req.URLs != "" {
+		settings[ConfigKeyAppriseURLs] = req.URLs
+	}
+
+	for key, val := range settings {
+		if err := ws.bridge.SetConfigValue(key, val); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to save %s: %v", key, err)})
+			return
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Notification settings saved"})
+}
+
+func (ws *WebServer) testAppriseConnectionHandler(c *gin.Context) {
+	var req struct {
+		APIURL string `json:"api_url"`
+	}
+	json.NewDecoder(c.Request.Body).Decode(&req)
+
+	apiURL := req.APIURL
+	if apiURL == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Apprise API URL is required", "connected": false})
+		return
+	}
+
+	if err := ws.bridge.notifier.TestConnection(apiURL); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "connected": false})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Apprise API connection successful", "connected": true})
+}
+
+func (ws *WebServer) testNotificationHandler(c *gin.Context) {
+	apiURL, err := ws.bridge.GetConfigValue(ConfigKeyAppriseAPIURL)
+	if err != nil || apiURL == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Apprise API URL is not configured"})
+		return
+	}
+
+	var req struct {
+		Event string `json:"event"`
+	}
+	json.NewDecoder(c.Request.Body).Decode(&req)
+
+	title, body, notifType := testNotificationContent(req.Event)
+
+	mode, _ := ws.bridge.GetConfigValue(ConfigKeyAppriseMode)
+
+	if mode == "stateful" {
+		key, _ := ws.bridge.GetConfigValue(ConfigKeyAppriseKey)
+		if key == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Persistent storage key is not configured"})
+			return
+		}
+		tag, _ := ws.bridge.GetConfigValue(ConfigKeyAppriseTag)
+		err = ws.bridge.notifier.SendStateful(apiURL, key, tag, title, body, notifType)
+	} else {
+		rawURLs, err2 := ws.bridge.GetConfigValue(ConfigKeyAppriseURLs)
+		if err2 != nil || rawURLs == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "No notification URLs configured"})
+			return
+		}
+
+		var urls []string
+		for _, u := range strings.Split(rawURLs, "\n") {
+			u = strings.TrimSpace(u)
+			if u != "" {
+				urls = append(urls, u)
+			}
+		}
+		if len(urls) == 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "No valid notification URLs configured"})
+			return
+		}
+
+		err = ws.bridge.notifier.Send(apiURL, urls, title, body, notifType)
+	}
+
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Test notification sent successfully"})
+}
+
+func testNotificationContent(event string) (title, body, notifType string) {
+	dummyToolheads := []toolheadNotifyInfo{{
+		ID: 0, SpoolID: 42, Mapped: true, Resolved: true,
+		SpoolName: "Generic PLA", Brand: "Prusament", Material: "PLA",
+		EstimateGrams: 12.4, UsedGrams: 12.4, RemainingWeight: 850.0,
+	}}
+
+	switch event {
+	case "print_started":
+		return buildPrintStartedMessage("Test Printer", "benchy.gcode", dummyToolheads)
+	case "print_done":
+		return buildPrintEndedMessage("Test Printer", "benchy.gcode", "1h 24m", true, 1.0, dummyToolheads)
+	case "print_failed":
+		failed := []toolheadNotifyInfo{{
+			ID: 0, SpoolID: 42, Mapped: true, Resolved: true,
+			SpoolName: "Generic PLA", Brand: "Prusament", Material: "PLA",
+			EstimateGrams: 12.4, UsedGrams: 5.6, RemainingWeight: 844.4,
+		}}
+		return buildPrintEndedMessage("Test Printer", "benchy.gcode", "38m", false, 0.45, failed)
+	case "low_filament":
+		return buildLowFilamentMessage("Test Printer", "benchy.gcode", "Generic PLA", 42, 8.2, 12.4)
+	case "auto_paused":
+		return buildAutoPausedMessage("Test Printer", "Generic PLA", 42, 0, 8.2, 12.4)
+	case "offline":
+		return buildOfflineMessage("Test Printer", "192.168.1.100")
+	case "online":
+		return buildOnlineMessage("Test Printer", "192.168.1.100")
+	default:
+		return buildPrintStartedMessage("Test Printer", "benchy.gcode", dummyToolheads)
+	}
 }
 
 // getRunoutWarningsHandler returns all unacknowledged low-filament warnings


### PR DESCRIPTION
## Summary

- Adds push notification support via [Apprise API](https://github.com/caronc/apprise-api) sidecar, supporting 100+ notification services (Discord, Telegram, Slack, email, etc.)
- Supports both **stateless** (notification URLs sent per request) and **stateful** (persistent storage key + tag) Apprise API modes — stateful is recommended when running Apprise API as a shared notification hub
- Notifies on 7 events: print started, print completed, print failed/cancelled, low filament warning, print auto-paused, printer offline, and printer back online
- Print start notifications include per-toolhead filament needs vs. remaining; print end notifications include duration and actual usage per toolhead
- Low filament and auto-pause notifications clearly state what spool is short, by how much, and how to resume
- New "Notifications" sub-tab in Settings with master enable toggle, Apprise API URL with connection test, stateful/stateless mode selector, per-event toggles, and per-event test buttons
- Per-event test buttons send realistic dummy notifications matching the real message format; buttons are hidden when settings have unsaved changes
- Inline status messages (no alert popups) for save and test operations
- All notifications fire asynchronously via goroutines — never block the monitoring loop
- Message formatting extracted into pure builder functions shared by both the real notification path and the test handler

## Test plan

- [x] `go build`, `go test`, and `go vet` all pass cleanly
- [x] Run with an Apprise API sidecar, enable notifications in Settings > Notifications
- [x] Verify Test Connection button validates API reachability using the URL in the input field (not saved config)
- [x] Verify stateful mode works — set key and tag, test delivers via `/notify/{key}`
- [x] Verify stateless mode works — set notification URLs, test delivers via `/notify/`
- [x] Verify mode toggle shows/hides the correct fields (URLs vs key/tag)
- [x] Verify per-event test buttons send realistic dummy notifications for each event type
- [x] Verify test buttons are hidden when notification settings have unsaved changes
- [x] Verify save status message persists (not cleared immediately)
- [x] Verify default values (key: "apprise", tag: "all") are filled in when saving with empty fields
- [x] Verify printer offline/online notifications fire on connectivity changes
- [x] Verify disabling master toggle suppresses all notifications
- [x] Verify individual event toggles work independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)