### PR TITLE
feat: sync spool locations with Spoolman on assign/unassign

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Spoolman is an excellent tool to track one's filament inventory. However, manual
 - **Smart Scanning**: Two-step NFC workflow - scan spool + location for instant assignment
 - **Quick-Assign Tags**: Single-printer setups get one-scan tags that assign a spool straight to the printer, no location tag needed
 - **Location Tracking**: Track spools in custom locations (dryboxes) or printer toolheads
+- **Location Sync**: Assigning or unassigning spools in the dashboard automatically updates their Spoolman location
+- **Refresh from Spoolman**: One-click button to read spool locations from Spoolman and map matching spools to toolheads
 - **Smart Housekeeping**: If a new spool is "loaded" to a printer, the previous will be returned to a pre-set default location
 
 ## Why FilaBridge?
@@ -212,6 +214,16 @@ The web interface provides:
 3. **Monitor usage**: The system automatically tracks and updates filament usage
 4. **Handle errors**: Acknowledge any print processing errors that require manual intervention
 
+### Spoolman Location Sync
+
+FilaBridge keeps Spoolman spool locations in sync with your toolhead assignments:
+
+- **Assigning a spool** (via the dashboard dropdown, NFC, or QR code) sets the spool's Spoolman location to `"PrinterName - ToolheadName"` (e.g. `"Core One - Toolhead 0"`). Any other spool already at that location is moved to your configured default storage location (or has its location cleared if none is set).
+- **Unassigning a spool** moves it to the default storage location, or clears its location if none is configured.
+- **Refresh from Spoolman**: Each printer card has a "Refresh" button that reads all spool locations from Spoolman and maps any whose location matches `"PrinterName - ToolheadName"` to the corresponding toolhead. This is useful after editing locations directly in Spoolman or when setting up a fresh FilaBridge instance against an existing Spoolman database.
+
+The location naming convention is `"PrinterName - ToolheadName"`, where PrinterName is the name you gave the printer in FilaBridge and ToolheadName is either a custom name you set or the default `"Toolhead N"`. You can create these locations in Spoolman ahead of time and assign spools to them there, then use the Refresh button to pull the mappings into FilaBridge.
+
 ### NFC Tag / QR Code Management
 
 1. **Generate QR Codes**: Navigate to NFC Management tab in the web interface
@@ -241,6 +253,7 @@ The web interface also provides REST API endpoints:
 - `GET /api/nfc/assign` - Handle NFC tag scans (spool, location, or both in one URL)
 - `GET /api/nfc/urls` - Get all NFC URLs with QR codes
 - `GET /api/nfc/session/status` - Check NFC session status
+- `POST /api/refresh_from_spoolman` - Refresh toolhead mappings from Spoolman spool locations
 - `GET/POST /api/locations`, `PUT/DELETE /api/locations/{name}` - Manage locations
 - `WS /ws/status` - WebSocket endpoint for real-time status updates
 

--- a/bridge.go
+++ b/bridge.go
@@ -982,6 +982,9 @@ func (b *FilamentBridge) SetToolheadMapping(printerName string, toolheadID int, 
 	// Unlock before potentially calling AssignSpoolToLocation (which may need locks)
 	b.mutex.Unlock()
 
+	// Update the newly loaded spool's location in Spoolman
+	b.updateSpoolLocationForToolhead(printerName, toolheadID, spoolID)
+
 	if enabled && previousSpoolID > 0 && previousSpoolID != spoolID {
 		// Get the configured default location
 		locationName, err := b.GetAutoAssignPreviousSpoolLocation()
@@ -1010,6 +1013,66 @@ func (b *FilamentBridge) SetToolheadMapping(printerName string, toolheadID int, 
 	}
 
 	return nil
+}
+
+// updateSpoolLocationForToolhead sets a spool's Spoolman location to
+// "{PrinterName} - {ToolheadDisplayName}". Failures are logged but
+// never propagated so the toolhead mapping itself is not rolled back.
+func (b *FilamentBridge) updateSpoolLocationForToolhead(printerName string, toolheadID int, spoolID int) {
+	displayName := fmt.Sprintf("Toolhead %d", toolheadID)
+	printerConfigs, err := b.GetAllPrinterConfigs()
+	if err == nil {
+		for printerID, printerConfig := range printerConfigs {
+			if printerConfig.Name == printerName {
+				if name, err := b.GetToolheadName(printerID, toolheadID); err == nil {
+					displayName = name
+				}
+				break
+			}
+		}
+	}
+
+	locationName := fmt.Sprintf("%s - %s", printerName, displayName)
+
+	// Move any other spools currently at this location to the default storage location.
+	b.evictSpoolsFromLocation(locationName, spoolID)
+
+	if err := b.spoolman.UpdateSpoolLocation(spoolID, locationName); err != nil {
+		log.Printf("Warning: Failed to update Spoolman location for spool %d to '%s': %v", spoolID, locationName, err)
+	}
+}
+
+// evictSpoolsFromLocation moves any spools at the given location (except excludeSpoolID)
+// to the auto-assign default storage location, or clears their location if unconfigured.
+func (b *FilamentBridge) evictSpoolsFromLocation(locationName string, excludeSpoolID int) {
+	spools, err := b.spoolman.GetAllSpools()
+	if err != nil {
+		log.Printf("Warning: Failed to fetch spools to check location '%s': %v", locationName, err)
+		return
+	}
+
+	destLocation := ""
+	enabled, err := b.GetAutoAssignPreviousSpoolEnabled()
+	if err == nil && enabled {
+		if name, err := b.GetAutoAssignPreviousSpoolLocation(); err == nil && name != "" {
+			if loc, err := b.spoolman.FindLocationByName(name); err == nil && loc != nil {
+				destLocation = name
+			}
+		}
+	}
+
+	for _, spool := range spools {
+		if spool.ID == excludeSpoolID || spool.Location != locationName {
+			continue
+		}
+		if err := b.spoolman.UpdateSpoolLocation(spool.ID, destLocation); err != nil {
+			log.Printf("Warning: Failed to move spool %d from '%s': %v", spool.ID, locationName, err)
+		} else if destLocation != "" {
+			log.Printf("Moved spool %d from '%s' to '%s'", spool.ID, locationName, destLocation)
+		} else {
+			log.Printf("Cleared location for spool %d (was '%s')", spool.ID, locationName)
+		}
+	}
 }
 
 // GetToolheadMappings gets all toolhead mappings for a printer
@@ -1078,17 +1141,47 @@ func (b *FilamentBridge) GetAllToolheadMappings() (map[string]map[int]ToolheadMa
 // UnmapToolhead removes a spool mapping from a toolhead
 func (b *FilamentBridge) UnmapToolhead(printerName string, toolheadID int) error {
 	b.mutex.Lock()
-	defer b.mutex.Unlock()
 
-	_, err := b.db.Exec(
+	var spoolID int
+	err := b.db.QueryRow(
+		"SELECT spool_id FROM toolhead_mappings WHERE printer_name = ? AND toolhead_id = ?",
+		printerName, toolheadID,
+	).Scan(&spoolID)
+	if err != nil && err != sql.ErrNoRows {
+		b.mutex.Unlock()
+		return fmt.Errorf("failed to query toolhead mapping: %w", err)
+	}
+
+	_, err = b.db.Exec(
 		"DELETE FROM toolhead_mappings WHERE printer_name = ? AND toolhead_id = ?",
 		printerName, toolheadID,
 	)
 	if err != nil {
+		b.mutex.Unlock()
 		return fmt.Errorf("failed to unmap toolhead: %w", err)
 	}
 
+	b.mutex.Unlock()
 	log.Printf("Unmapped %s toolhead %d", printerName, toolheadID)
+
+	if spoolID > 0 {
+		locationName := ""
+		enabled, err := b.GetAutoAssignPreviousSpoolEnabled()
+		if err == nil && enabled {
+			locationName, _ = b.GetAutoAssignPreviousSpoolLocation()
+			if locationName != "" {
+				loc, err := b.spoolman.FindLocationByName(locationName)
+				if err != nil || loc == nil {
+					log.Printf("Warning: Auto-assign location '%s' does not exist, clearing spool %d location", locationName, spoolID)
+					locationName = ""
+				}
+			}
+		}
+		if err := b.spoolman.UpdateSpoolLocation(spoolID, locationName); err != nil {
+			log.Printf("Warning: Failed to update Spoolman location for spool %d: %v", spoolID, err)
+		}
+	}
+
 	return nil
 }
 

--- a/nfc.go
+++ b/nfc.go
@@ -265,46 +265,11 @@ func (b *FilamentBridge) cleanupExpiredSessions() error {
 // AssignSpoolToLocation assigns a spool to a location and updates Spoolman
 func (b *FilamentBridge) AssignSpoolToLocation(spoolID int, printerName string, toolheadID int, locationName string, isPrinterLocation bool) error {
 	if isPrinterLocation {
-		// This is a printer toolhead location
-		// Update FilaBridge toolhead mapping
+		// SetToolheadMapping also updates the spool's Spoolman location.
 		if err := b.SetToolheadMapping(printerName, toolheadID, spoolID); err != nil {
 			return fmt.Errorf("failed to set toolhead mapping: %w", err)
 		}
-
-		// Get toolhead display name (custom or default)
-		// Find printer ID first
-		printerConfigs, err := b.GetAllPrinterConfigs()
-		var displayName string
-		if err == nil {
-			for printerID, printerConfig := range printerConfigs {
-				if printerConfig.Name == printerName {
-					name, err := b.GetToolheadName(printerID, toolheadID)
-					if err == nil {
-						displayName = name
-					} else {
-						displayName = fmt.Sprintf("Toolhead %d", toolheadID)
-					}
-					break
-				}
-			}
-		}
-		if displayName == "" {
-			displayName = fmt.Sprintf("Toolhead %d", toolheadID)
-		}
-
-		// Update Spoolman location using proper location entities with custom name
-		locationName := fmt.Sprintf("%s - %s", printerName, displayName)
-
-		// Note: Spoolman API doesn't support creating locations via POST.
-		// The location will be auto-created when we update the spool's location field.
-
-		if err := b.spoolman.UpdateSpoolLocation(spoolID, locationName); err != nil {
-			// If Spoolman update fails, we should still log it but not fail the entire operation
-			// since the FilaBridge mapping is more critical
-			log.Printf("Warning: Failed to update Spoolman location for spool %d: %v", spoolID, err)
-		}
-
-		log.Printf("Successfully assigned spool %d to %s toolhead %d (%s)", spoolID, printerName, toolheadID, displayName)
+		log.Printf("Successfully assigned spool %d to %s toolhead %d", spoolID, printerName, toolheadID)
 	} else {
 		// This is a non-printer location (drybox, storage, etc.)
 		// First, check if this spool is currently assigned to any toolhead and clear it

--- a/spoolman.go
+++ b/spoolman.go
@@ -39,14 +39,13 @@ type SpoolmanSpool struct {
 	FirstUsed       string                 `json:"first_used"`
 	LastUsed        string                 `json:"last_used"`
 	Archived        bool                   `json:"archived"`
-	LocationID      *int                   `json:"location_id"` // Reference to Spoolman Location entity
-	Extra           map[string]interface{} `json:"extra"`
+	Location string                 `json:"location"`
+	Extra    map[string]interface{} `json:"extra"`
 
 	// Computed fields for easier access
 	Name     string `json:"name"`     // Computed from filament.name
 	Brand    string `json:"brand"`    // Computed from filament.vendor.name
 	Material string `json:"material"` // Computed from filament.material
-	Location string `json:"location"` // Spool location (e.g., "Printer1 - Toolhead 0") - kept for backward compatibility
 }
 
 // SpoolmanFilament represents a filament type from Spoolman
@@ -533,7 +532,6 @@ func (c *SpoolmanClient) RenameLocation(oldName, newName string) error {
 
 // UpdateSpoolLocation updates a spool's location in Spoolman using text-based location field
 func (c *SpoolmanClient) UpdateSpoolLocation(spoolID int, locationName string) error {
-	// Use text-based location assignment - Spoolman will create the location if it doesn't exist
 	return c.updateSpoolLocationText(spoolID, locationName)
 }
 

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -189,6 +189,27 @@
     color: #fff !important;
 }
 
+.refresh-from-spoolman-btn {
+    background: rgba(255,255,255,0.1);
+    color: rgba(255,255,255,0.75);
+    padding: 4px 10px;
+    border: 1px solid rgba(255,255,255,0.2);
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 12px;
+    transition: all 0.2s ease;
+}
+
+.refresh-from-spoolman-btn:hover {
+    background: rgba(255,255,255,0.2);
+    color: #fff;
+}
+
+.refresh-from-spoolman-btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+
 .edit-spool-btn {
     background: #007bff; /* Fallback color */
     color: white;

--- a/static/js/dropdowns.js
+++ b/static/js/dropdowns.js
@@ -390,21 +390,21 @@ function removeSpoolFromOtherDropdowns(spoolId) {
     });
 }
 
-// Refresh all dropdowns to update available spools
+// Refresh all dropdowns to update available spools (debounced)
+let _refreshTimer = null;
 async function refreshAllDropdowns() {
-    // Get all dropdowns except the one that was just updated
-    const allDropdowns = document.querySelectorAll('.custom-dropdown');
-    
-    for (const dropdown of allDropdowns) {
-        // Skip if dropdown is currently open
-        const content = dropdown.querySelector('.dropdown-content');
-        if (content && content.classList.contains('show')) {
-            continue;
+    if (_refreshTimer) clearTimeout(_refreshTimer);
+    _refreshTimer = setTimeout(async () => {
+        _refreshTimer = null;
+        const allDropdowns = document.querySelectorAll('.custom-dropdown');
+        for (const dropdown of allDropdowns) {
+            const content = dropdown.querySelector('.dropdown-content');
+            if (content && content.classList.contains('show')) {
+                continue;
+            }
+            await loadAvailableSpools(dropdown);
         }
-        
-        // Refresh the available spools for this dropdown
-        await loadAvailableSpools(dropdown);
-    }
+    }, 300);
 }
 
 // Update edit button visibility and data based on selected spool

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -573,6 +573,42 @@ function convertTimestampsToLocal() {
     });
 }
 
+function initRefreshButtons() {
+    document.addEventListener('click', function(e) {
+        const btn = e.target.closest('.refresh-from-spoolman-btn');
+        if (!btn) return;
+
+        const printerId = btn.dataset.printerId;
+        if (!printerId || btn.disabled) return;
+
+        btn.disabled = true;
+        const origText = btn.textContent;
+        btn.textContent = '⏳';
+
+        fetch('/api/refresh_from_spoolman', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({ printer_id: printerId })
+        })
+        .then(r => r.json())
+        .then(data => {
+            if (data.error) {
+                btn.textContent = '✗';
+                console.error('Refresh error:', data.error);
+                setTimeout(() => { btn.textContent = origText; btn.disabled = false; }, 1500);
+            } else {
+                btn.textContent = '✓';
+                setTimeout(() => location.reload(), 500);
+            }
+        })
+        .catch(err => {
+            console.error('Refresh failed:', err);
+            btn.textContent = '✗';
+            setTimeout(() => { btn.textContent = origText; btn.disabled = false; }, 1500);
+        });
+    });
+}
+
 // Initialize everything when page loads
 document.addEventListener('DOMContentLoaded', function() {
     convertTimestampsToLocal();
@@ -582,4 +618,5 @@ document.addEventListener('DOMContentLoaded', function() {
     initCustomDropdowns();
     initColorSwatches();
     initEditButtonColors();
+    initRefreshButtons();
 });

--- a/templates/status.html
+++ b/templates/status.html
@@ -77,7 +77,10 @@
                 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
                     <h3>Toolhead Mappings</h3>
                 </div>
-                <h4>Map Spools to Toolheads</h4>
+                <div style="display: flex; justify-content: space-between; align-items: center;">
+                    <h4 style="margin: 0;">Map Spools to Toolheads</h4>
+                    <button class="refresh-from-spoolman-btn" data-printer-id="{{$printerID}}" title="Refresh toolhead mappings from Spoolman locations">↻ Refresh</button>
+                </div>
                 <div style="margin-top: 15px;">
                     {{$mapping := index $.Status.ToolheadMappings $printerID}}
                     {{range $toolheadID := generateToolheadIDs $printerConfig.Toolheads}}

--- a/web.go
+++ b/web.go
@@ -153,6 +153,7 @@ func (ws *WebServer) setupRoutes() {
 		api.GET("/spools", ws.spoolsHandler)
 		api.GET("/filaments", ws.filamentsHandler)
 		api.POST("/map_toolhead", ws.mapToolheadHandler)
+		api.POST("/refresh_from_spoolman", ws.refreshFromSpoolmanHandler)
 		api.GET("/available_spools", ws.availableSpoolsHandler)
 		api.GET("/spoolman/test", ws.testSpoolmanConnectionHandler)
 		api.GET("/spoolman/debug", ws.debugSpoolmanHandler)
@@ -570,6 +571,85 @@ func (ws *WebServer) mapToolheadHandler(c *gin.Context) {
 		}
 		c.JSON(http.StatusOK, gin.H{"message": "Toolhead mapped successfully"})
 	}
+}
+
+// refreshFromSpoolmanHandler reads spool locations from Spoolman and maps
+// spools to toolheads whose location string matches "{PrinterName} - {DisplayName}".
+func (ws *WebServer) refreshFromSpoolmanHandler(c *gin.Context) {
+	var req struct {
+		PrinterID string `json:"printer_id" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid JSON"})
+		return
+	}
+
+	configs, err := ws.bridge.GetAllPrinterConfigs()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to load printer configs"})
+		return
+	}
+	printerConfig, ok := configs[req.PrinterID]
+	if !ok {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Printer not found"})
+		return
+	}
+
+	toolheadNames, err := ws.bridge.GetAllToolheadNames(req.PrinterID)
+	if err != nil {
+		toolheadNames = make(map[int]string)
+	}
+
+	spools, err := ws.bridge.spoolman.GetAllSpools()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch spools from Spoolman"})
+		return
+	}
+
+	spoolsByLocation := make(map[string]SpoolmanSpool)
+	for _, spool := range spools {
+		if spool.Location == "" {
+			continue
+		}
+		if existing, ok := spoolsByLocation[spool.Location]; !ok || spool.RemainingWeight > existing.RemainingWeight {
+			spoolsByLocation[spool.Location] = spool
+		}
+	}
+
+	type refreshResult struct {
+		ToolheadID  int    `json:"toolhead_id"`
+		SpoolID     int    `json:"spool_id"`
+		DisplayName string `json:"display_name"`
+	}
+	var mapped []refreshResult
+	var errors []string
+
+	for toolheadID := 0; toolheadID < printerConfig.Toolheads; toolheadID++ {
+		displayName := fmt.Sprintf("Toolhead %d", toolheadID)
+		if name, ok := toolheadNames[toolheadID]; ok {
+			displayName = name
+		}
+		locationName := fmt.Sprintf("%s - %s", printerConfig.Name, displayName)
+
+		spool, ok := spoolsByLocation[locationName]
+		if !ok {
+			continue
+		}
+		if err := ws.bridge.clearSpoolFromAllToolheads(spool.ID); err != nil {
+			log.Printf("Warning: Failed to clear spool %d from existing toolheads: %v", spool.ID, err)
+		}
+		if err := ws.bridge.SetToolheadMapping(printerConfig.Name, toolheadID, spool.ID); err != nil {
+			errors = append(errors, fmt.Sprintf("%s: %v", displayName, err))
+			continue
+		}
+		mapped = append(mapped, refreshResult{
+			ToolheadID:  toolheadID,
+			SpoolID:     spool.ID,
+			DisplayName: displayName,
+		})
+	}
+
+	c.JSON(http.StatusOK, gin.H{"mapped": mapped, "errors": errors})
 }
 
 // availableSpoolsHandler returns spools available for assignment to a specific toolhead


### PR DESCRIPTION
## Summary
- Assigning or unassigning spools via the dashboard, NFC, or QR code now updates the spool's Spoolman location automatically using the `"PrinterName - ToolheadName"` convention
- New **Refresh** button on each printer card reads spool locations from Spoolman and maps matching spools to toolheads
- When loading a spool into a toolhead, any other spool already at that Spoolman location is evicted to the configured default storage location (or cleared)
- Consolidated location update logic into `SetToolheadMapping` — removed ~35 lines of duplicate code from `nfc.go`
- Debounced `refreshAllDropdowns()` (300ms) to prevent excessive `/api/available_spools` calls
- Updated README with location sync documentation and naming convention

## Test plan
- [x] Assign a spool to a toolhead via the dropdown — verify its Spoolman location updates to `"PrinterName - ToolheadName"`
- [x] Unassign a spool — verify it moves to the default storage location (or location is cleared)
- [x] Set spool locations in Spoolman matching the naming convention, click Refresh — verify toolhead mappings are created
- [x] Assign a spool to a toolhead that already has another spool at that location — verify the previous spool is evicted
- [ ] Assign/unassign via NFC or QR code — verify same location update behavior
- [x] Verify no excessive `/api/available_spools` calls in browser network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)