### PR TITLE
feat: multi-color filament rendering support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Spoolman is an excellent tool to track one's filament inventory. However, manual
 - **Persistent Storage**: SQLite database stores toolhead mappings and complete print history
 - **High Performance**: Single lightweight binary with a single DB file, minimal resource usage, fast execution
 - **Web-based Config**: No config files needed - manage everything through the web UI
+- **Multi-Color Filament Support**: Renders coaxial and longitudinal multi-color filaments with split swatches matching Spoolman's UI
 - **Smart Spool Search**: Search and filter spools by ID, material, brand, or name with real-time filtering
 - **Error Handling**: Print error detection with acknowledgment system for failed filament tracking
 - **Auto-mapping**: Automatic spool assignment when selecting from dropdown menus

--- a/spoolman.go
+++ b/spoolman.go
@@ -63,6 +63,8 @@ type SpoolmanFilament struct {
 	SettingsExtruderTemp int                    `json:"settings_extruder_temp"`
 	SettingsBedTemp      int                    `json:"settings_bed_temp"`
 	ColorHex             string                 `json:"color_hex"`
+	MultiColorHexes      string                 `json:"multi_color_hexes"`
+	MultiColorDirection  string                 `json:"multi_color_direction"`
 	ExternalID           string                 `json:"external_id"`
 	Extra                map[string]interface{} `json:"extra"`
 	Archived             bool                   `json:"archived"`

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -171,6 +171,19 @@
     background-color: #ccc;
 }
 
+.color-swatch-multi {
+    width: 20px;
+    height: 20px;
+    border-radius: 3px;
+    border: 1px solid #666;
+    flex-shrink: 0;
+    display: flex;
+    overflow: hidden;
+}
+.color-swatch-multi.coaxial { flex-direction: row; }
+.color-swatch-multi.longitudinal { flex-direction: column; }
+.color-swatch-multi .color-stripe { flex: 1 1 0px; }
+
 /* Toolhead Specific Styles */
 .toolhead-select {
     background: rgba(255,255,255,0.1) !important;

--- a/static/js/dropdowns.js
+++ b/static/js/dropdowns.js
@@ -47,14 +47,18 @@ async function loadAvailableSpools(dropdown) {
             option.className = 'dropdown-option';
             option.setAttribute('data-value', spool.id);
             option.setAttribute('data-color', spool.filament?.color_hex || '');
-            
+            option.setAttribute('data-multi-color-hexes', spool.filament?.multi_color_hexes || '');
+            option.setAttribute('data-multi-color-direction', spool.filament?.multi_color_direction || '');
+
             if (currentSpoolId && spool.id.toString() === currentSpoolId) {
                 option.classList.add('selected');
             }
-            
-            const colorSwatch = document.createElement('div');
-            colorSwatch.className = 'color-swatch';
-            colorSwatch.style.backgroundColor = '#' + (spool.filament?.color_hex || 'ccc');
+
+            const colorSwatch = buildColorSwatch(
+                spool.filament?.color_hex,
+                spool.filament?.multi_color_hexes,
+                spool.filament?.multi_color_direction
+            );
             
             const optionText = document.createElement('div');
             optionText.className = 'option-text';
@@ -74,16 +78,18 @@ async function loadAvailableSpools(dropdown) {
                 const selectedText = option.querySelector('.option-text').textContent;
                 const selectedColor = option.dataset.color;
                 const selectedValue = option.dataset.value;
-                
+                const selectedMultiHexes = option.dataset.multiColorHexes || '';
+                const selectedMultiDir = option.dataset.multiColorDirection || '';
+
                 // Update hidden input value
                 if (hiddenInput) {
                     hiddenInput.value = selectedValue;
                 }
-                
+
                 // Update selected state
                 optionsContainer.querySelectorAll('.dropdown-option').forEach(opt => opt.classList.remove('selected'));
                 option.classList.add('selected');
-                
+
                 // Close dropdown
                 const content = dropdown.querySelector('.dropdown-content');
                 const arrow = dropdown.querySelector('.dropdown-arrow');
@@ -91,23 +97,23 @@ async function loadAvailableSpools(dropdown) {
                 const button = dropdown.querySelector('.dropdown-button');
                 button.classList.remove('open');
                 arrow.classList.remove('open');
-                
+
                 // Auto-map the spool if a spool is selected (not "Empty")
                 if (selectedValue && selectedValue !== '') {
-                    await autoMapSpool(dropdown, selectedValue, selectedText, selectedColor);
+                    await autoMapSpool(dropdown, selectedValue, selectedText, selectedColor, selectedMultiHexes, selectedMultiDir);
                 } else {
                     // Handle empty selection - unmap the toolhead
                     await autoMapSpool(dropdown, '0', selectedText, '');
                 }
-                
+
                 // Update edit button after selection
                 const toolheadRow = dropdown.closest('.toolhead-mapping-row');
                 if (toolheadRow) {
-                    updateEditButton(toolheadRow, selectedValue, selectedColor);
+                    updateEditButton(toolheadRow, selectedValue, selectedColor, selectedMultiHexes, selectedMultiDir);
                 }
             });
         });
-        
+
     } catch (error) {
         console.error('Error loading available spools:', error);
     }
@@ -173,39 +179,41 @@ function initCustomDropdowns() {
         content.querySelectorAll('.dropdown-option').forEach(option => {
             option.addEventListener('click', async (e) => {
                 e.stopPropagation();
-                
+
                 // Update button text and selected state
                 const selectedText = option.querySelector('.option-text').textContent;
                 const selectedColor = option.dataset.color;
                 const selectedValue = option.dataset.value;
-                
+                const selectedMultiHexes = option.dataset.multiColorHexes || '';
+                const selectedMultiDir = option.dataset.multiColorDirection || '';
+
                 // Update hidden input value
                 const hiddenInput = dropdown.querySelector('input[type="hidden"]');
                 if (hiddenInput) {
                     hiddenInput.value = selectedValue;
                 }
-                
+
                 // Update selected state
                 content.querySelectorAll('.dropdown-option').forEach(opt => opt.classList.remove('selected'));
                 option.classList.add('selected');
-                
+
                 // Close dropdown
                 content.classList.remove('show');
                 button.classList.remove('open');
                 arrow.classList.remove('open');
-                
+
                 // Auto-map the spool if a spool is selected (not "Empty")
                 if (selectedValue && selectedValue !== '') {
-                    await autoMapSpool(dropdown, selectedValue, selectedText, selectedColor);
+                    await autoMapSpool(dropdown, selectedValue, selectedText, selectedColor, selectedMultiHexes, selectedMultiDir);
                 } else {
                     // Handle empty selection - unmap the toolhead
                     await autoMapSpool(dropdown, '0', selectedText, '');
                 }
-                
+
                 // Update edit button after selection
                 const toolheadRow = dropdown.closest('.toolhead-mapping-row');
                 if (toolheadRow) {
-                    updateEditButton(toolheadRow, selectedValue, selectedColor);
+                    updateEditButton(toolheadRow, selectedValue, selectedColor, selectedMultiHexes, selectedMultiDir);
                 }
             });
         });
@@ -266,7 +274,7 @@ function initCustomDropdowns() {
 }
 
 // Auto-map spool to toolhead when selected
-async function autoMapSpool(dropdown, selectedValue, selectedText, selectedColor) {
+async function autoMapSpool(dropdown, selectedValue, selectedText, selectedColor, multiColorHexes, multiColorDirection) {
     const toolheadRow = dropdown.closest('.toolhead-mapping-row');
     if (!toolheadRow) {
         console.error('Could not find toolhead mapping row');
@@ -291,17 +299,27 @@ async function autoMapSpool(dropdown, selectedValue, selectedText, selectedColor
     
     const printerName = printerNameElement.textContent;
     
+    // Helper to build button content with swatch and arrow
+    function setButtonContent(arrowText) {
+        const btnContent = document.createElement('div');
+        btnContent.style.cssText = 'display: flex; align-items: center; gap: 10px;';
+        btnContent.appendChild(buildColorSwatch(selectedColor, multiColorHexes, multiColorDirection));
+        const spanEl = document.createElement('span');
+        spanEl.textContent = selectedText;
+        btnContent.appendChild(spanEl);
+        button.innerHTML = '';
+        button.appendChild(btnContent);
+        const arrowEl = document.createElement('span');
+        arrowEl.className = 'dropdown-arrow';
+        arrowEl.textContent = arrowText;
+        button.appendChild(arrowEl);
+    }
+
     // Show loading state
     const button = dropdown.querySelector('.dropdown-button');
     const originalContent = button.innerHTML;
-    button.innerHTML = `
-        <div style="display: flex; align-items: center; gap: 10px;">
-            <div class="color-swatch" style="background-color: #${selectedColor};"></div>
-            <span>${selectedText}</span>
-        </div>
-        <span class="dropdown-arrow">⏳</span>
-    `;
-    
+    setButtonContent('⏳');
+
     try {
         const response = await fetch('/api/map_toolhead', {
             method: 'POST',
@@ -312,9 +330,9 @@ async function autoMapSpool(dropdown, selectedValue, selectedText, selectedColor
                 spool_id: selectedValue === '0' ? 0 : parseInt(selectedValue)
             })
         });
-        
+
         const data = await response.json();
-        
+
         if (data.error) {
             // Handle conflict errors specifically
             if (data.error.includes('is already assigned to')) {
@@ -322,53 +340,41 @@ async function autoMapSpool(dropdown, selectedValue, selectedText, selectedColor
             } else {
                 alert(`Error mapping spool: ${data.error}`);
             }
-            
+
             // Revert to previous selection
             button.innerHTML = originalContent;
             // Update edit button to previous state
-            updateEditButton(toolheadRow, selectedValue, selectedColor);
+            updateEditButton(toolheadRow, selectedValue, selectedColor, multiColorHexes, multiColorDirection);
             return;
         }
-        
+
         // Success - show brief success indicator
-        button.innerHTML = `
-            <div style="display: flex; align-items: center; gap: 10px;">
-                <div class="color-swatch" style="background-color: #${selectedColor};"></div>
-                <span>${selectedText}</span>
-            </div>
-            <span class="dropdown-arrow">✅</span>
-        `;
-        
+        setButtonContent('✅');
+
         // Update edit button visibility and data
-        updateEditButton(toolheadRow, selectedValue, selectedColor);
-        
+        updateEditButton(toolheadRow, selectedValue, selectedColor, multiColorHexes, multiColorDirection);
+
         // Reset to normal state after 2 seconds
         setTimeout(() => {
-            button.innerHTML = `
-                <div style="display: flex; align-items: center; gap: 10px;">
-                    <div class="color-swatch" style="background-color: #${selectedColor};"></div>
-                    <span>${selectedText}</span>
-                </div>
-                <span class="dropdown-arrow">▼</span>
-            `;
+            setButtonContent('▼');
         }, 2000);
-        
+
         // Only remove spools from other dropdowns if we're mapping a spool (not unmapping)
         if (selectedValue !== '0') {
             // Immediately remove the mapped spool from all other dropdowns
             removeSpoolFromOtherDropdowns(selectedValue);
-            
+
             // Refresh all other dropdowns to update available spools
             refreshAllDropdowns();
         } else {
             // If unmapping, just refresh all dropdowns to show the newly available spool
             refreshAllDropdowns();
         }
-        
+
     } catch (error) {
         console.error('Error mapping spool:', error);
         alert('Error mapping spool: ' + error.message);
-        
+
         // Revert to previous selection
         button.innerHTML = originalContent;
     }
@@ -408,27 +414,19 @@ async function refreshAllDropdowns() {
 }
 
 // Update edit button visibility and data based on selected spool
-function updateEditButton(toolheadRow, selectedValue, selectedColor = '') {
+function updateEditButton(toolheadRow, selectedValue, selectedColor = '', multiColorHexes = '', multiColorDirection = '') {
     const editButton = toolheadRow.querySelector('.edit-spool-btn');
     if (!editButton) return;
-    
+
     if (selectedValue && selectedValue !== '' && selectedValue !== '0') {
-        // Show button and update spool ID
         editButton.classList.remove('hidden');
         editButton.setAttribute('data-spool-id', selectedValue);
         editButton.setAttribute('onclick', `openSpoolmanEdit(${selectedValue})`);
-        
-        // Set button color to match filament color
-        if (selectedColor) {
-            editButton.style.backgroundColor = '#' + selectedColor;
-            editButton.style.borderColor = '#' + selectedColor;
-        } else {
-            // Fallback to default blue if no color
-            editButton.style.backgroundColor = '#007bff';
-            editButton.style.borderColor = '#007bff';
-        }
+
+        const style = buildColorStyle(selectedColor, multiColorHexes, multiColorDirection);
+        editButton.style.background = style.background;
+        editButton.style.borderColor = style.borderColor;
     } else {
-        // Hide button
         editButton.classList.add('hidden');
         editButton.setAttribute('data-spool-id', '');
         editButton.setAttribute('onclick', 'openSpoolmanEdit(null)');

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -540,24 +540,61 @@ function apiUrl(path) {
     return `${window.location.origin}${path}`;
 }
 
-// Initialize color swatches based on data-color attributes
+function buildColorSwatch(colorHex, multiColorHexes, multiColorDirection) {
+    if (multiColorHexes) {
+        const colors = multiColorHexes.split(',');
+        const container = document.createElement('div');
+        container.className = 'color-swatch-multi ' + (multiColorDirection || 'coaxial');
+        colors.forEach(c => {
+            const stripe = document.createElement('div');
+            stripe.className = 'color-stripe';
+            stripe.style.backgroundColor = '#' + c.trim();
+            container.appendChild(stripe);
+        });
+        return container;
+    }
+    const swatch = document.createElement('div');
+    swatch.className = 'color-swatch';
+    swatch.style.backgroundColor = '#' + (colorHex || 'ccc');
+    return swatch;
+}
+
+function buildColorStyle(colorHex, multiColorHexes, multiColorDirection) {
+    if (multiColorHexes) {
+        const colors = multiColorHexes.split(',').map(c => '#' + c.trim());
+        const direction = multiColorDirection === 'longitudinal' ? 'to bottom' : 'to right';
+        const gradient = 'linear-gradient(' + direction + ', ' + colors.join(', ') + ')';
+        return { background: gradient, borderColor: colors[0] };
+    }
+    const color = '#' + (colorHex || '007bff');
+    return { background: color, borderColor: color };
+}
+
 function initColorSwatches() {
     document.querySelectorAll('.color-swatch[data-color]').forEach(swatch => {
-        const color = swatch.getAttribute('data-color');
-        if (color) {
-            swatch.style.backgroundColor = '#' + color;
+        const multiHexes = swatch.getAttribute('data-multi-color-hexes');
+        const multiDir = swatch.getAttribute('data-multi-color-direction');
+        if (multiHexes) {
+            const multiSwatch = buildColorSwatch(null, multiHexes, multiDir);
+            swatch.replaceWith(multiSwatch);
+        } else {
+            const color = swatch.getAttribute('data-color');
+            if (color) {
+                swatch.style.backgroundColor = '#' + color;
+            }
         }
     });
 }
 
-// Initialize edit button colors from data attributes
 function initEditButtonColors() {
-    document.querySelectorAll('.edit-spool-btn[data-color-hex]').forEach(button => {
-        const colorHex = button.getAttribute('data-color-hex');
-        if (colorHex) {
-            button.style.backgroundColor = '#' + colorHex;
-            button.style.borderColor = '#' + colorHex;
-        }
+    document.querySelectorAll('.edit-spool-btn[data-color-hex], .edit-spool-btn[data-multi-color-hexes]').forEach(button => {
+        const style = buildColorStyle(
+            button.getAttribute('data-color-hex'),
+            button.getAttribute('data-multi-color-hexes'),
+            button.getAttribute('data-multi-color-direction')
+        );
+        button.style.background = style.background;
+        button.style.borderColor = style.borderColor;
     });
 }
 

--- a/static/js/websocket.js
+++ b/static/js/websocket.js
@@ -161,15 +161,19 @@ function updateSpoolData(spools) {
             option.className = 'dropdown-option';
             option.setAttribute('data-value', spool.id);
             option.setAttribute('data-color', spool.filament?.color_hex || '');
-            
-            const colorSwatch = document.createElement('div');
-            colorSwatch.className = 'color-swatch';
-            colorSwatch.style.backgroundColor = '#' + (spool.filament?.color_hex || 'ccc');
-            
+            option.setAttribute('data-multi-color-hexes', spool.filament?.multi_color_hexes || '');
+            option.setAttribute('data-multi-color-direction', spool.filament?.multi_color_direction || '');
+
+            const colorSwatch = buildColorSwatch(
+                spool.filament?.color_hex,
+                spool.filament?.multi_color_hexes,
+                spool.filament?.multi_color_direction
+            );
+
             const optionText = document.createElement('div');
             optionText.className = 'option-text';
             optionText.textContent = `[${spool.id}] ${spool.material || 'Unknown Material'} - ${spool.brand || 'Unknown Brand'} - ${spool.name || 'Unnamed Spool'}${spool.remaining_weight != null ? ` (${Math.round(spool.remaining_weight)}g remaining)` : ''}`;
-            
+
             option.appendChild(colorSwatch);
             option.appendChild(optionText);
             optionsContainer.appendChild(option);
@@ -179,22 +183,24 @@ function updateSpoolData(spools) {
         optionsContainer.querySelectorAll('.dropdown-option').forEach(option => {
             option.addEventListener('click', async function(e) {
                 e.stopPropagation();
-                
+
                 // Update button text and selected state
                 const selectedText = option.querySelector('.option-text').textContent;
                 const selectedColor = option.dataset.color;
                 const selectedValue = option.dataset.value;
-                
+                const selectedMultiHexes = option.dataset.multiColorHexes || '';
+                const selectedMultiDir = option.dataset.multiColorDirection || '';
+
                 // Update hidden input value
                 const hiddenInput = dropdown.querySelector('input[type="hidden"]');
                 if (hiddenInput) {
                     hiddenInput.value = selectedValue;
                 }
-                
+
                 // Update selected state
                 optionsContainer.querySelectorAll('.dropdown-option').forEach(opt => opt.classList.remove('selected'));
                 option.classList.add('selected');
-                
+
                 // Close dropdown
                 const content = dropdown.querySelector('.dropdown-content');
                 const button = dropdown.querySelector('.dropdown-button');
@@ -202,19 +208,19 @@ function updateSpoolData(spools) {
                 content.classList.remove('show');
                 button.classList.remove('open');
                 arrow.classList.remove('open');
-                
+
                 // Auto-map the spool if a spool is selected (not "Empty")
                 if (selectedValue && selectedValue !== '') {
-                    await autoMapSpool(dropdown, selectedValue, selectedText, selectedColor);
+                    await autoMapSpool(dropdown, selectedValue, selectedText, selectedColor, selectedMultiHexes, selectedMultiDir);
                 } else {
                     // Handle empty selection - unmap the toolhead
                     await autoMapSpool(dropdown, '0', selectedText, '');
                 }
-                
+
                 // Update edit button after selection
                 const toolheadRow = dropdown.closest('.toolhead-mapping-row');
                 if (toolheadRow) {
-                    updateEditButton(toolheadRow, selectedValue, selectedColor);
+                    updateEditButton(toolheadRow, selectedValue, selectedColor, selectedMultiHexes, selectedMultiDir);
                 }
             });
         });
@@ -275,25 +281,32 @@ function updateToolheadMappings(mappings) {
                 if (spoolOption) {
                     const selectedText = spoolOption.querySelector('.option-text').textContent;
                     const selectedColor = spoolOption.dataset.color;
-                    
+                    const selectedMultiHexes = spoolOption.dataset.multiColorHexes || '';
+                    const selectedMultiDir = spoolOption.dataset.multiColorDirection || '';
+
                     // Update button display
-                    dropdownButton.innerHTML = `
-                        <div style="display: flex; align-items: center; gap: 10px;">
-                            <div class="color-swatch" style="background-color: #${selectedColor || 'ccc'};"></div>
-                            <span>${selectedText}</span>
-                        </div>
-                        <span class="dropdown-arrow">▼</span>
-                    `;
-                    
+                    const swatchEl = buildColorSwatch(selectedColor, selectedMultiHexes, selectedMultiDir);
+                    const btnContent = document.createElement('div');
+                    btnContent.style.cssText = 'display: flex; align-items: center; gap: 10px;';
+                    btnContent.appendChild(swatchEl);
+                    const spanText = document.createElement('span');
+                    spanText.textContent = selectedText;
+                    btnContent.appendChild(spanText);
+                    dropdownButton.innerHTML = '';
+                    dropdownButton.appendChild(btnContent);
+                    const arrow = document.createElement('span');
+                    arrow.className = 'dropdown-arrow';
+                    arrow.textContent = '▼';
+                    dropdownButton.appendChild(arrow);
+
                     // Mark as selected
                     optionsContainer.querySelectorAll('.dropdown-option').forEach(opt => {
                         opt.classList.remove('selected');
                     });
                     spoolOption.classList.add('selected');
-                    
+
                     // Update edit button
-                    updateEditButton(toolheadRow, spoolId, selectedColor);
-                    
+                    updateEditButton(toolheadRow, spoolId, selectedColor, selectedMultiHexes, selectedMultiDir);
                 }
             }
         } else {

--- a/templates/status.html
+++ b/templates/status.html
@@ -96,7 +96,7 @@
                                     {{if $mappedSpool.SpoolID}}
                                     {{range $.Spools}}
                                     {{if eq .ID $mappedSpool.SpoolID}}
-                                    <div class="color-swatch" data-color="{{.Filament.ColorHex}}"></div>
+                                    <div class="color-swatch" data-color="{{.Filament.ColorHex}}" data-multi-color-hexes="{{.Filament.MultiColorHexes}}" data-multi-color-direction="{{.Filament.MultiColorDirection}}"></div>
                                     <span>[{{.ID}}] {{if .Material}}{{.Material}}{{else}}Unknown Material{{end}} - {{if .Brand}}{{.Brand}}{{else}}Unknown Brand{{end}} - {{if .Name}}{{.Name}}{{else}}Unnamed Spool{{end}}{{if .RemainingWeight}} ({{printf "%.0f" .RemainingWeight}}g remaining){{end}}</span>
                                     {{end}}
                                     {{end}}
@@ -117,8 +117,8 @@
                                         <div class="option-text">Empty</div>
                                     </div>
                                     {{range $.Spools}}
-                                    <div class="dropdown-option" data-value="{{.ID}}" data-color="{{.Filament.ColorHex}}" {{if $mappedSpool.SpoolID}}{{if eq .ID $mappedSpool.SpoolID}}class="selected"{{end}}{{end}}>
-                                        <div class="color-swatch" data-color="{{.Filament.ColorHex}}"></div>
+                                    <div class="dropdown-option" data-value="{{.ID}}" data-color="{{.Filament.ColorHex}}" data-multi-color-hexes="{{.Filament.MultiColorHexes}}" data-multi-color-direction="{{.Filament.MultiColorDirection}}" {{if $mappedSpool.SpoolID}}{{if eq .ID $mappedSpool.SpoolID}}class="selected"{{end}}{{end}}>
+                                        <div class="color-swatch" data-color="{{.Filament.ColorHex}}" data-multi-color-hexes="{{.Filament.MultiColorHexes}}" data-multi-color-direction="{{.Filament.MultiColorDirection}}"></div>
                                         <div class="option-text">[{{.ID}}] {{if .Material}}{{.Material}}{{else}}Unknown Material{{end}} - {{if .Brand}}{{.Brand}}{{else}}Unknown Brand{{end}} - {{if .Name}}{{.Name}}{{else}}Unnamed Spool{{end}}{{if .RemainingWeight}} ({{printf "%.0f" .RemainingWeight}}g remaining){{end}}</div>
                                     </div>
                                     {{end}}
@@ -134,6 +134,8 @@
                                 {{range $.Spools}}
                                 {{if eq .ID $mappedSpool.SpoolID}}
                                 data-color-hex="{{.Filament.ColorHex}}"
+                                data-multi-color-hexes="{{.Filament.MultiColorHexes}}"
+                                data-multi-color-direction="{{.Filament.MultiColorDirection}}"
                                 {{end}}
                                 {{end}}
                                 {{end}}>


### PR DESCRIPTION
## Summary
- Adds multi-color filament swatch rendering matching Spoolman's UI — coaxial filaments split vertically (left/right stripes), longitudinal split horizontally (top/bottom)
- Edit buttons use CSS gradients for multi-color spools instead of solid color
- All five color rendering paths updated: server-rendered init, dropdown open, WebSocket spool update, WebSocket mapping update, and spool selection

## Changes
- `spoolman.go`: Added `MultiColorHexes` and `MultiColorDirection` fields to `SpoolmanFilament`
- `static/css/components.css`: New `.color-swatch-multi` styles with coaxial/longitudinal flex directions
- `static/js/main.js`: Added `buildColorSwatch()` and `buildColorStyle()` shared helpers; updated `initColorSwatches()` and `initEditButtonColors()`
- `static/js/dropdowns.js`: Updated `loadAvailableSpools()`, `autoMapSpool()`, `updateEditButton()`, and all click handlers to pass multi-color data
- `static/js/websocket.js`: Updated `updateSpoolData()` and `updateToolheadMappings()` to use multi-color swatches
- `templates/status.html`: Added `data-multi-color-hexes` and `data-multi-color-direction` attributes to swatches, dropdown options, and edit buttons
- `README.md`: Added multi-color filament support to features list

## Test plan
- [ ] Load dashboard with multi-color spools (coaxial and longitudinal) — swatches show split colors
- [ ] Single-color spools still render as solid squares
- [ ] Open dropdown — multi-color spool options show split swatches
- [ ] Select a multi-color spool — button swatch, edit button gradient, and loading/success states all render correctly
- [ ] WebSocket live updates preserve multi-color rendering after spool data refresh
- [ ] WebSocket mapping updates show correct multi-color swatches
- [ ] Edit button shows horizontal gradient for coaxial, vertical gradient for longitudinal
- [ ] `go build`, `go test`, `go vet` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)