### PR TITLE
feat: preserve active tab across page reloads

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -19,7 +19,14 @@ function switchTab(tabName) {
     
     // Add active class to clicked tab
     event.target.classList.add('active');
-    
+
+    // Update URL hash (skip for default status tab to keep URL clean)
+    if (tabName === 'status') {
+        history.replaceState(null, '', location.pathname);
+    } else {
+        location.hash = tabName;
+    }
+
     // Load print history when its tab is opened
     if (tabName === 'history') {
         loadPrintHistory();
@@ -171,6 +178,8 @@ function switchSettingsTab(tabName, clickedElement) {
         });
     }
     
+    location.hash = 'settings/' + tabName;
+
     // Load data for specific tabs
     if (tabName === 'getting-started') {
         // Getting Started tab doesn't need data loading
@@ -582,4 +591,27 @@ document.addEventListener('DOMContentLoaded', function() {
     initCustomDropdowns();
     initColorSwatches();
     initEditButtonColors();
+    restoreTabFromHash();
 });
+
+function restoreTabFromHash() {
+    const hash = location.hash.replace('#', '');
+    if (!hash) return;
+
+    const parts = hash.split('/');
+    const mainTab = parts[0];
+    const subTab = parts[1];
+
+    // Find and click the main tab button
+    const tabBtn = document.querySelector(`.tab[onclick*="'${mainTab}'"]`);
+    if (!tabBtn) return;
+    tabBtn.click();
+
+    if (!subTab) return;
+
+    if (mainTab === 'settings') {
+        switchSettingsTab(subTab);
+    } else if (mainTab === 'nfc') {
+        switchNfcTab(subTab);
+    }
+}

--- a/static/js/nfc.js
+++ b/static/js/nfc.js
@@ -28,6 +28,8 @@ function switchNfcTab(tabName, clickedElement) {
         });
     }
     
+    location.hash = 'nfc/' + tabName;
+
     // Load data for specific tabs
     if (tabName === 'spool-tags') {
         loadSpoolTags();


### PR DESCRIPTION
## Summary
- Stores the current tab and sub-tab in the URL hash (e.g. `#settings/printers`, `#nfc/filament-tags`)
- Page reloads and bookmarks restore the same view
- The default status tab keeps a clean URL with no hash

## Changes
- `static/js/main.js`: `switchTab()` and `switchSettingsTab()` update `location.hash`; `restoreTabFromHash()` on page load
- `static/js/nfc.js`: `switchNfcTab()` updates `location.hash`

## Test plan
- [ ] Click through tabs — URL hash updates (e.g. `#history`, `#settings/printers`)
- [ ] Reload page on a non-default tab — same tab restores
- [ ] Click status tab — hash is removed, URL is clean
- [ ] Bookmark a sub-tab URL, open in new tab — correct tab shown
- [ ] NFC sub-tabs work the same way (`#nfc/location-tags`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)