### PR TITLE
V1.1 prep

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -1033,6 +1033,82 @@ func (b *FilamentBridge) relocateSpool(spoolID int) {
 	}
 }
 
+// ImportSummary reports the result of importing toolhead mappings from Spoolman.
+type ImportSummary struct {
+	Imported  int      `json:"imported"`  // toolheads mapped from a Spoolman spool location
+	Unmatched []string `json:"unmatched"` // toolhead locations with no spool in Spoolman
+	Conflicts []string `json:"conflicts"` // toolhead locations claimed by more than one spool
+}
+
+// ImportMappingsFromSpoolman rebuilds a printer's toolhead mappings from
+// Spoolman: for each of the printer's toolheads, the spool Spoolman shows at the
+// "Printer - Toolhead" location is mapped to that toolhead (and removed from any
+// other toolhead it was on). It is additive — toolheads with no matching spool
+// in Spoolman keep their current mapping and are reported so the user can assign
+// one in Spoolman. Pull-only: Spoolman is never written to.
+func (b *FilamentBridge) ImportMappingsFromSpoolman(printerName string) (ImportSummary, error) {
+	var summary ImportSummary
+
+	_, cfg, found, err := b.findPrinterByName(printerName)
+	if err != nil {
+		return summary, err
+	}
+	if !found {
+		return summary, fmt.Errorf("printer %q not found", printerName)
+	}
+
+	spools, err := b.spoolman.GetAllSpools()
+	if err != nil {
+		return summary, fmt.Errorf("failed to load spools from Spoolman: %w", err)
+	}
+
+	// Group spool IDs by Spoolman location so a location claimed by more than
+	// one spool can be flagged as a conflict instead of guessed at.
+	byLocation := make(map[string][]int)
+	for _, s := range spools {
+		if s.Location != "" {
+			byLocation[s.Location] = append(byLocation[s.Location], s.ID)
+		}
+	}
+
+	for tid := 0; tid < cfg.Toolheads; tid++ {
+		locName := b.toolheadLocationName(printerName, tid)
+		ids := byLocation[locName]
+		switch {
+		case len(ids) == 0:
+			summary.Unmatched = append(summary.Unmatched, locName)
+		case len(ids) > 1:
+			summary.Conflicts = append(summary.Conflicts, fmt.Sprintf("%s (%d spools)", locName, len(ids)))
+		default:
+			if err := b.importSetMapping(printerName, tid, ids[0]); err != nil {
+				summary.Conflicts = append(summary.Conflicts, fmt.Sprintf("%s: %v", locName, err))
+				continue
+			}
+			summary.Imported++
+		}
+	}
+
+	log.Printf("Imported %d mapping(s) for %s from Spoolman (%d unmatched, %d conflict)",
+		summary.Imported, printerName, len(summary.Unmatched), len(summary.Conflicts))
+	return summary, nil
+}
+
+// importSetMapping sets a toolhead mapping directly (no Spoolman write) and first
+// removes the spool from any other toolhead it was on, preserving the
+// one-spool-one-toolhead invariant.
+func (b *FilamentBridge) importSetMapping(printerName string, toolheadID, spoolID int) error {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+	if _, err := b.db.Exec("DELETE FROM toolhead_mappings WHERE spool_id = ?", spoolID); err != nil {
+		return err
+	}
+	_, err := b.db.Exec(
+		"INSERT OR REPLACE INTO toolhead_mappings (printer_name, toolhead_id, spool_id, mapped_at) VALUES (?, ?, ?, ?)",
+		printerName, toolheadID, spoolID, time.Now(),
+	)
+	return err
+}
+
 // GetToolheadMappings gets all toolhead mappings for a printer
 func (b *FilamentBridge) GetToolheadMappings(printerName string) (map[int]ToolheadMapping, error) {
 	rows, err := b.db.Query(

--- a/import_test.go
+++ b/import_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestImportMappingsFromSpoolman covers rebuilding a printer's toolhead mappings
+// from Spoolman spool locations: a clean import, a location claimed by two spools
+// (conflict, skipped), a toolhead with no spool (unmatched, reported), moving a
+// spool off a stale FilaBridge mapping, and ignoring other printers' locations.
+func TestImportMappingsFromSpoolman(t *testing.T) {
+	printer := newFakePrusaLink(t)
+	spoolman := newFakeSpoolman(t)
+	b := newTestBridge(t, printer, spoolman)
+
+	// A managed 3-toolhead printer to import.
+	if err := b.SavePrinterConfig("printer_multi", PrinterConfig{Name: "Multi", IPAddress: "127.0.0.1:2", APIKey: "k", Toolheads: 3}); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.ReloadConfig(); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, id := range []int{1, 2, 3, 4, 5} {
+		spoolman.Spools[id] = &fakeSpool{ID: id, Name: "Spool", RemainingWeight: 500}
+	}
+
+	// Pre-map spool 1 to TestPrinter/0 in FilaBridge (stale), then move it to
+	// Multi/0 in Spoolman — the import should follow Spoolman and vacate TestPrinter.
+	if err := b.SetToolheadMapping("TestPrinter", 0, 1); err != nil {
+		t.Fatalf("pre-map: %v", err)
+	}
+	spoolman.Spools[1].Location = "Multi - Toolhead 0"       // clean import
+	spoolman.Spools[2].Location = "Multi - Toolhead 1"       // conflict...
+	spoolman.Spools[3].Location = "Multi - Toolhead 1"       // ...with spool 2
+	spoolman.Spools[4].Location = "TestPrinter - Toolhead 0" // another printer's location
+	spoolman.Spools[5].Location = "Ghost - Toolhead 0"       // unmanaged printer
+	// Multi - Toolhead 2 intentionally has no spool -> unmatched
+
+	summary, err := b.ImportMappingsFromSpoolman("Multi")
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+
+	if summary.Imported != 1 {
+		t.Errorf("imported = %d, want 1", summary.Imported)
+	}
+	if len(summary.Conflicts) != 1 || !strings.Contains(summary.Conflicts[0], "Multi - Toolhead 1") {
+		t.Errorf("conflicts = %v, want one for Multi - Toolhead 1", summary.Conflicts)
+	}
+	if len(summary.Unmatched) != 1 || summary.Unmatched[0] != "Multi - Toolhead 2" {
+		t.Errorf("unmatched = %v, want [Multi - Toolhead 2]", summary.Unmatched)
+	}
+
+	if id, _ := b.GetToolheadMapping("Multi", 0); id != 1 {
+		t.Errorf("Multi/0 mapping = %d, want 1", id)
+	}
+	if id, _ := b.GetToolheadMapping("Multi", 1); id != 0 {
+		t.Errorf("Multi/1 (conflict) mapping = %d, want unmapped", id)
+	}
+	if id, _ := b.GetToolheadMapping("Multi", 2); id != 0 {
+		t.Errorf("Multi/2 (unmatched) mapping = %d, want unmapped", id)
+	}
+	// Spool 1 moved to Multi/0, so its stale TestPrinter/0 mapping is gone.
+	if id, _ := b.GetToolheadMapping("TestPrinter", 0); id != 0 {
+		t.Errorf("TestPrinter/0 = %d, want vacated (spool moved to Multi)", id)
+	}
+}

--- a/spoolman.go
+++ b/spoolman.go
@@ -63,6 +63,8 @@ type SpoolmanFilament struct {
 	SettingsExtruderTemp int                    `json:"settings_extruder_temp"`
 	SettingsBedTemp      int                    `json:"settings_bed_temp"`
 	ColorHex             string                 `json:"color_hex"`
+	MultiColorHexes      string                 `json:"multi_color_hexes"`     // comma-separated hex list (no #) for multi-color filament; color_hex still holds a primary color
+	MultiColorDirection  string                 `json:"multi_color_direction"` // "coaxial" | "longitudinal" (not currently used for rendering)
 	ExternalID           string                 `json:"external_id"`
 	Extra                map[string]interface{} `json:"extra"`
 	Archived             bool                   `json:"archived"`

--- a/static/js/dropdowns.js
+++ b/static/js/dropdowns.js
@@ -340,13 +340,10 @@ async function autoMapSpool(dropdown, selectedValue, selectedText, selectedColor
         if (selectedValue !== '0') {
             // Immediately remove the mapped spool from all other dropdowns
             removeSpoolFromOtherDropdowns(selectedValue);
-            
-            // Refresh all other dropdowns to update available spools
-            refreshAllDropdowns();
-        } else {
-            // If unmapping, just refresh all dropdowns to show the newly available spool
-            refreshAllDropdowns();
         }
+        // Refresh all other dropdowns to update available spools (debounced so a
+        // burst of mappings doesn't fire a request storm)
+        debouncedRefreshAllDropdowns();
         
     } catch (error) {
         console.error('Error mapping spool:', error);
@@ -371,6 +368,14 @@ function removeSpoolFromOtherDropdowns(spoolId) {
             optionToRemove.remove();
         }
     });
+}
+
+// Debounce refreshAllDropdowns so a burst of map/unmap operations collapses to a
+// single refresh instead of one /api/available_spools sweep per operation.
+let refreshDropdownsTimer = null;
+function debouncedRefreshAllDropdowns() {
+    clearTimeout(refreshDropdownsTimer);
+    refreshDropdownsTimer = setTimeout(refreshAllDropdowns, 300);
 }
 
 // Refresh all dropdowns to update available spools

--- a/static/js/dropdowns.js
+++ b/static/js/dropdowns.js
@@ -1,10 +1,10 @@
 // FilaBridge Dashboard - Dropdown Functionality
 
 // setDropdownButton renders the standard swatch + label + arrow button content
-function setDropdownButton(button, color, text, arrow) {
+function setDropdownButton(button, color, multiColor, text, arrow) {
     button.innerHTML = `
         <div style="display: flex; align-items: center; gap: 10px;">
-            <div class="color-swatch" style="background-color: #${color || 'ccc'};"></div>
+            <div class="color-swatch" style="background: ${swatchBackground(color, multiColor)};"></div>
             <span>${text}</span>
         </div>
         <span class="dropdown-arrow">${arrow}</span>
@@ -72,14 +72,15 @@ async function loadAvailableSpools(dropdown) {
             option.className = 'dropdown-option';
             option.setAttribute('data-value', spool.id);
             option.setAttribute('data-color', spool.filament?.color_hex || '');
-            
+            option.setAttribute('data-multi-color', spool.filament?.multi_color_hexes || '');
+
             if (currentSpoolId && spool.id.toString() === currentSpoolId) {
                 option.classList.add('selected');
             }
-            
+
             const colorSwatch = document.createElement('div');
             colorSwatch.className = 'color-swatch';
-            colorSwatch.style.backgroundColor = '#' + (spool.filament?.color_hex || 'ccc');
+            applySwatch(colorSwatch, spool.filament?.color_hex, spool.filament?.multi_color_hexes);
             
             const optionText = document.createElement('div');
             optionText.className = 'option-text';
@@ -98,6 +99,7 @@ async function loadAvailableSpools(dropdown) {
                 // Update button text and selected state
                 const selectedText = option.querySelector('.option-text').textContent;
                 const selectedColor = option.dataset.color;
+                const selectedMulti = option.dataset.multiColor;
                 const selectedValue = option.dataset.value;
                 
                 // Update hidden input value
@@ -113,10 +115,10 @@ async function loadAvailableSpools(dropdown) {
 
                 // Auto-map the spool if a spool is selected (not "Empty")
                 if (selectedValue && selectedValue !== '') {
-                    await autoMapSpool(dropdown, selectedValue, selectedText, selectedColor);
+                    await autoMapSpool(dropdown, selectedValue, selectedText, selectedColor, selectedMulti);
                 } else {
                     // Handle empty selection - unmap the toolhead
-                    await autoMapSpool(dropdown, '0', selectedText, '');
+                    await autoMapSpool(dropdown, '0', selectedText, '', '');
                 }
                 
                 // Update edit button after selection
@@ -196,6 +198,7 @@ function initCustomDropdowns() {
                 // Update button text and selected state
                 const selectedText = option.querySelector('.option-text').textContent;
                 const selectedColor = option.dataset.color;
+                const selectedMulti = option.dataset.multiColor;
                 const selectedValue = option.dataset.value;
                 
                 // Update hidden input value
@@ -212,10 +215,10 @@ function initCustomDropdowns() {
 
                 // Auto-map the spool if a spool is selected (not "Empty")
                 if (selectedValue && selectedValue !== '') {
-                    await autoMapSpool(dropdown, selectedValue, selectedText, selectedColor);
+                    await autoMapSpool(dropdown, selectedValue, selectedText, selectedColor, selectedMulti);
                 } else {
                     // Handle empty selection - unmap the toolhead
-                    await autoMapSpool(dropdown, '0', selectedText, '');
+                    await autoMapSpool(dropdown, '0', selectedText, '', '');
                 }
                 
                 // Update edit button after selection
@@ -264,7 +267,7 @@ function initCustomDropdowns() {
 }
 
 // Auto-map spool to toolhead when selected
-async function autoMapSpool(dropdown, selectedValue, selectedText, selectedColor) {
+async function autoMapSpool(dropdown, selectedValue, selectedText, selectedColor, selectedMulti) {
     const toolheadRow = dropdown.closest('.toolhead-mapping-row');
     if (!toolheadRow) {
         console.error('Could not find toolhead mapping row');
@@ -292,7 +295,7 @@ async function autoMapSpool(dropdown, selectedValue, selectedText, selectedColor
     // Show loading state
     const button = dropdown.querySelector('.dropdown-button');
     const originalContent = button.innerHTML;
-    setDropdownButton(button, selectedColor, selectedText, '⏳');
+    setDropdownButton(button, selectedColor, selectedMulti, selectedText, '⏳');
     
     try {
         const response = await fetch('/api/map_toolhead', {
@@ -323,14 +326,14 @@ async function autoMapSpool(dropdown, selectedValue, selectedText, selectedColor
         }
         
         // Success - show brief success indicator
-        setDropdownButton(button, selectedColor, selectedText, '✅');
+        setDropdownButton(button, selectedColor, selectedMulti, selectedText, '✅');
 
         // Update edit button visibility and data
         updateEditButton(toolheadRow, selectedValue, selectedColor);
 
         // Reset to normal state after 2 seconds
         setTimeout(() => {
-            setDropdownButton(button, selectedColor, selectedText, '▼');
+            setDropdownButton(button, selectedColor, selectedMulti, selectedText, '▼');
         }, 2000);
         
         // Only remove spools from other dropdowns if we're mapping a spool (not unmapping)

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -532,6 +532,32 @@ function clearPrintHistory() {
     });
 }
 
+// refreshPrinterMappings imports a printer's toolhead mappings from the spool
+// locations recorded in Spoolman, then reloads so the mappings show. Additive:
+// toolheads Spoolman has no spool for are reported so the user can set them up
+// in Spoolman.
+async function refreshPrinterMappings(printerName) {
+    try {
+        const data = await apiRequest('/api/import-mappings', {
+            method: 'POST',
+            body: { printer_name: printerName }
+        });
+
+        let msg = `Imported ${data.imported} mapping(s) for "${printerName}" from Spoolman.`;
+        if (data.conflicts && data.conflicts.length) {
+            msg += `\n\n⚠️ Skipped (more than one spool at the location):\n- ${data.conflicts.join('\n- ')}`;
+        }
+        if (data.unmatched && data.unmatched.length) {
+            msg += `\n\n⚠️ No spool is at these locations in Spoolman:\n- ${data.unmatched.join('\n- ')}\n\n`
+                + 'Assign a spool to each of these locations in Spoolman, then Refresh again.';
+        }
+        alert(msg);
+        location.reload();
+    } catch (error) {
+        alert('Error importing mappings: ' + error.message);
+    }
+}
+
 // Utility Functions
 function apiUrl(path) {
     // Ensure path starts with / if not already

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -91,9 +91,13 @@ async function loadPrintHistory() {
         const historyData = await historyRes.json();
 
         const spoolNames = {};
+        const spoolColors = {};
         if (spoolsRes && spoolsRes.ok) {
             const spools = await spoolsRes.json();
-            spools.forEach(s => { spoolNames[s.id] = s.name; });
+            spools.forEach(s => {
+                spoolNames[s.id] = s.name;
+                spoolColors[s.id] = { color: s.filament?.color_hex, multi: s.filament?.multi_color_hexes };
+            });
         }
 
         const history = historyData.history || [];
@@ -109,6 +113,8 @@ async function loadPrintHistory() {
             const spoolLabel = spoolNames[h.spool_id]
                 ? `[${h.spool_id}] ${spoolNames[h.spool_id]}`
                 : `Spool #${h.spool_id}`;
+            const sc = spoolColors[h.spool_id] || {};
+            const spoolCell = `<span style="display:inline-flex;align-items:center;gap:8px;"><span class="color-swatch" style="background:${swatchBackground(sc.color, sc.multi)}"></span>${escapeHtml(spoolLabel)}</span>`;
             const statusClass = h.status === 'completed' ? 'history-status-completed' : 'history-status-cancelled';
             const statusLabel = h.status === 'completed' ? '✅ Completed' : '🛑 Cancelled/Failed';
             return `
@@ -116,7 +122,7 @@ async function loadPrintHistory() {
                     <td class="history-job">${escapeHtml(h.job_name)}</td>
                     <td>${escapeHtml(h.printer_name)}</td>
                     <td><span class="history-status ${statusClass}">${statusLabel}</span></td>
-                    <td>${escapeHtml(spoolLabel)}</td>
+                    <td>${spoolCell}</td>
                     <td>${h.filament_used.toFixed(1)}g</td>
                     <td>${finished.toLocaleString()}</td>
                     <td>${formatDuration(durationMs)}</td>
@@ -535,13 +541,37 @@ function apiUrl(path) {
     return `${window.location.origin}${path}`;
 }
 
-// Initialize color swatches based on data-color attributes
+// swatchBackground returns a CSS background value for a filament swatch: a
+// hard-stop gradient for multi-color filament (equal slices, matching how
+// Spoolman renders them), a solid color otherwise, or a neutral gray fallback.
+// Accepts hex values with or without a leading '#'.
+function swatchBackground(colorHex, multiColorHexes) {
+    const withHash = h => {
+        h = (h || '').trim();
+        return h ? (h[0] === '#' ? h : '#' + h) : '';
+    };
+    const multi = (multiColorHexes || '').split(',').map(s => s.trim()).filter(Boolean);
+    if (multi.length > 1) {
+        const n = multi.length;
+        const stops = multi.map((c, i) =>
+            `${withHash(c)} ${(i * 100 / n).toFixed(2)}% ${((i + 1) * 100 / n).toFixed(2)}%`
+        ).join(', ');
+        return `linear-gradient(90deg, ${stops})`;
+    }
+    return withHash(multi[0] || colorHex) || '#ccc';
+}
+
+// applySwatch sets an element's background from a filament's color info.
+function applySwatch(el, colorHex, multiColorHexes) {
+    if (el) {
+        el.style.background = swatchBackground(colorHex, multiColorHexes);
+    }
+}
+
+// Initialize color swatches based on data-color / data-multi-color attributes
 function initColorSwatches() {
     document.querySelectorAll('.color-swatch[data-color]').forEach(swatch => {
-        const color = swatch.getAttribute('data-color');
-        if (color) {
-            swatch.style.backgroundColor = '#' + color;
-        }
+        applySwatch(swatch, swatch.getAttribute('data-color'), swatch.getAttribute('data-multi-color'));
     });
 }
 

--- a/static/js/nfc.js
+++ b/static/js/nfc.js
@@ -71,10 +71,9 @@ async function loadSpoolTags(dataPromise) {
             item.dataset.color = url.color_hex;
             item.dataset.url = url.url;
             item.dataset.qr = url.qr_code_base64;
-            
-            const colorHex = url.color_hex || '#ccc';
+
             item.innerHTML = `
-                <div class="color-swatch" style="background-color: ${colorHex}"></div>
+                <div class="color-swatch" style="background: ${swatchBackground(url.color_hex, url.multi_color_hexes)}"></div>
                 <div class="item-info">
                     <div class="item-name">[${url.spool_id}] ${url.spool_name}</div>
                     <div class="item-details">${url.material} - ${url.brand}${url.remaining_weight != null ? ` - ${Math.round(url.remaining_weight)}g remaining` : ''}</div>
@@ -124,10 +123,9 @@ async function loadFilamentTags(dataPromise) {
             item.dataset.color = url.color_hex;
             item.dataset.url = url.url;
             item.dataset.qr = url.qr_code_base64;
-            
-            const colorHex = url.color_hex || '#ccc';
+
             item.innerHTML = `
-                <div class="color-swatch" style="background-color: ${colorHex}"></div>
+                <div class="color-swatch" style="background: ${swatchBackground(url.color_hex, url.multi_color_hexes)}"></div>
                 <div class="item-info">
                     <div class="item-name">${url.filament_name}</div>
                     <div class="item-details">${url.material} - ${url.brand}</div>

--- a/static/js/websocket.js
+++ b/static/js/websocket.js
@@ -151,10 +151,11 @@ function updateSpoolData(spools) {
             option.className = 'dropdown-option';
             option.setAttribute('data-value', spool.id);
             option.setAttribute('data-color', spool.filament?.color_hex || '');
-            
+            option.setAttribute('data-multi-color', spool.filament?.multi_color_hexes || '');
+
             const colorSwatch = document.createElement('div');
             colorSwatch.className = 'color-swatch';
-            colorSwatch.style.backgroundColor = '#' + (spool.filament?.color_hex || 'ccc');
+            applySwatch(colorSwatch, spool.filament?.color_hex, spool.filament?.multi_color_hexes);
             
             const optionText = document.createElement('div');
             optionText.className = 'option-text';
@@ -173,14 +174,15 @@ function updateSpoolData(spools) {
                 // Update button text and selected state
                 const selectedText = option.querySelector('.option-text').textContent;
                 const selectedColor = option.dataset.color;
+                const selectedMulti = option.dataset.multiColor;
                 const selectedValue = option.dataset.value;
-                
+
                 // Update hidden input value
                 const hiddenInput = dropdown.querySelector('input[type="hidden"]');
                 if (hiddenInput) {
                     hiddenInput.value = selectedValue;
                 }
-                
+
                 // Update selected state
                 optionsContainer.querySelectorAll('.dropdown-option').forEach(opt => opt.classList.remove('selected'));
                 option.classList.add('selected');
@@ -189,10 +191,10 @@ function updateSpoolData(spools) {
 
                 // Auto-map the spool if a spool is selected (not "Empty")
                 if (selectedValue && selectedValue !== '') {
-                    await autoMapSpool(dropdown, selectedValue, selectedText, selectedColor);
+                    await autoMapSpool(dropdown, selectedValue, selectedText, selectedColor, selectedMulti);
                 } else {
                     // Handle empty selection - unmap the toolhead
-                    await autoMapSpool(dropdown, '0', selectedText, '');
+                    await autoMapSpool(dropdown, '0', selectedText, '', '');
                 }
                 
                 // Update edit button after selection
@@ -259,9 +261,10 @@ function updateToolheadMappings(mappings) {
                 if (spoolOption) {
                     const selectedText = spoolOption.querySelector('.option-text').textContent;
                     const selectedColor = spoolOption.dataset.color;
-                    
+                    const selectedMulti = spoolOption.dataset.multiColor;
+
                     // Update button display
-                    setDropdownButton(dropdownButton, selectedColor, selectedText, '▼');
+                    setDropdownButton(dropdownButton, selectedColor, selectedMulti, selectedText, '▼');
                     
                     // Mark as selected
                     optionsContainer.querySelectorAll('.dropdown-option').forEach(opt => {

--- a/templates/status.html
+++ b/templates/status.html
@@ -76,6 +76,7 @@
             <div class="mapping-section">
                 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
                     <h3>Toolhead Mappings</h3>
+                    <button class="btn btn-small" onclick="refreshPrinterMappings('{{$printerData.Name}}')" title="Import toolhead mappings from the spool locations recorded in Spoolman">🔄 Refresh from Spoolman</button>
                 </div>
                 <h4>Map Spools to Toolheads</h4>
                 <div style="margin-top: 15px;">

--- a/templates/status.html
+++ b/templates/status.html
@@ -96,7 +96,7 @@
                                     {{if $mappedSpool.SpoolID}}
                                     {{range $.Spools}}
                                     {{if eq .ID $mappedSpool.SpoolID}}
-                                    <div class="color-swatch" data-color="{{.Filament.ColorHex}}"></div>
+                                    <div class="color-swatch" data-color="{{.Filament.ColorHex}}" data-multi-color="{{.Filament.MultiColorHexes}}"></div>
                                     <span>[{{.ID}}] {{if .Material}}{{.Material}}{{else}}Unknown Material{{end}} - {{if .Brand}}{{.Brand}}{{else}}Unknown Brand{{end}} - {{if .Name}}{{.Name}}{{else}}Unnamed Spool{{end}}{{if .RemainingWeight}} ({{printf "%.0f" .RemainingWeight}}g remaining){{end}}</span>
                                     {{end}}
                                     {{end}}
@@ -118,7 +118,7 @@
                                     </div>
                                     {{range $.Spools}}
                                     <div class="dropdown-option" data-value="{{.ID}}" data-color="{{.Filament.ColorHex}}" {{if $mappedSpool.SpoolID}}{{if eq .ID $mappedSpool.SpoolID}}class="selected"{{end}}{{end}}>
-                                        <div class="color-swatch" data-color="{{.Filament.ColorHex}}"></div>
+                                        <div class="color-swatch" data-color="{{.Filament.ColorHex}}" data-multi-color="{{.Filament.MultiColorHexes}}"></div>
                                         <div class="option-text">[{{.ID}}] {{if .Material}}{{.Material}}{{else}}Unknown Material{{end}} - {{if .Brand}}{{.Brand}}{{else}}Unknown Brand{{end}} - {{if .Name}}{{.Name}}{{else}}Unnamed Spool{{end}}{{if .RemainingWeight}} ({{printf "%.0f" .RemainingWeight}}g remaining){{end}}</div>
                                     </div>
                                     {{end}}

--- a/web.go
+++ b/web.go
@@ -1341,12 +1341,16 @@ func (ws *WebServer) nfcUrlsHandler(c *gin.Context) {
 
 		// Safely get color hex
 		colorHex := ""
-		if spool.Filament != nil && spool.Filament.ColorHex != "" {
-			colorHex = spool.Filament.ColorHex
-			// Ensure it starts with #
-			if !strings.HasPrefix(colorHex, "#") {
-				colorHex = "#" + colorHex
+		multiColorHexes := ""
+		if spool.Filament != nil {
+			if spool.Filament.ColorHex != "" {
+				colorHex = spool.Filament.ColorHex
+				// Ensure it starts with #
+				if !strings.HasPrefix(colorHex, "#") {
+					colorHex = "#" + colorHex
+				}
 			}
+			multiColorHexes = spool.Filament.MultiColorHexes
 		}
 
 		// Generate QR code (leave it empty and keep going if generation fails)
@@ -1364,6 +1368,7 @@ func (ws *WebServer) nfcUrlsHandler(c *gin.Context) {
 			"material":             spool.Material,
 			"brand":                spool.Brand,
 			"color_hex":            colorHex,
+			"multi_color_hexes":    multiColorHexes,
 			"remaining_weight":     spool.RemainingWeight,
 			"url":                  url,
 			"qr_code_base64":       qrCodeBase64,
@@ -1409,18 +1414,19 @@ func (ws *WebServer) nfcUrlsHandler(c *gin.Context) {
 		}
 
 		urls = append(urls, gin.H{
-			"type":           "filament",
-			"filament_id":    filament.ID,
-			"filament_name":  filament.Name,
-			"material":       filament.Material,
-			"brand":          brand,
-			"color_hex":      colorHex,
-			"extruder_temp":  filament.SettingsExtruderTemp,
-			"bed_temp":       filament.SettingsBedTemp,
-			"diameter":       filament.Diameter,
-			"density":        filament.Density,
-			"url":            url,
-			"qr_code_base64": qrCodeBase64,
+			"type":              "filament",
+			"filament_id":       filament.ID,
+			"filament_name":     filament.Name,
+			"material":          filament.Material,
+			"brand":             brand,
+			"color_hex":         colorHex,
+			"multi_color_hexes": filament.MultiColorHexes,
+			"extruder_temp":     filament.SettingsExtruderTemp,
+			"bed_temp":          filament.SettingsBedTemp,
+			"diameter":          filament.Diameter,
+			"density":           filament.Density,
+			"url":               url,
+			"qr_code_base64":    qrCodeBase64,
 		})
 	}
 

--- a/web.go
+++ b/web.go
@@ -172,6 +172,7 @@ func (ws *WebServer) setupRoutes() {
 		api.POST("/runout-warnings/:id/acknowledge", ws.acknowledgeRunoutWarningHandler)
 		api.GET("/print-history", ws.getPrintHistoryHandler)
 		api.DELETE("/print-history", ws.clearPrintHistoryHandler)
+		api.POST("/import-mappings", ws.importMappingsHandler)
 		api.GET("/nfc/assign", ws.nfcAssignHandler)
 		api.GET("/nfc/urls", ws.nfcUrlsHandler)
 		api.GET("/nfc/session/status", ws.nfcSessionStatusHandler)
@@ -1101,6 +1102,24 @@ func (ws *WebServer) getPrintHistoryHandler(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"history": history})
+}
+
+// importMappingsHandler rebuilds a printer's toolhead mappings from the spool
+// locations recorded in Spoolman and returns a summary.
+func (ws *WebServer) importMappingsHandler(c *gin.Context) {
+	var req struct {
+		PrinterName string `json:"printer_name" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid JSON"})
+		return
+	}
+	summary, err := ws.bridge.ImportMappingsFromSpoolman(req.PrinterName)
+	if err != nil {
+		internalError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, summary)
 }
 
 // clearPrintHistoryHandler deletes all stored print history entries


### PR DESCRIPTION
- Added Filament swatches to history and multi-color filament support

- Added a per-printer "Refresh from Spoolman" button in each printer's Toolhead Mappings. It:

    - Reads Spoolman's spool locations and, for each of that printer's toolheads, maps the spool Spoolman shows at "Printer - Toolhead" and is scoped to that printer only (other printers' locations ignored).
    -  Is additive, so a spool with no match keeps its current mapping and the toolhead is reported.
    -  Moves a spool off any stale toolhead it was on (keeps one-spool-one-toolhead).
    - Pull-only, does not write to Spoolman to avoid unexpected overwritings.
    - Popup summary listing imported count, any conflicts (a location with 2+ spools, skipped), and a clear warning of the toolhead locations Spoolman has no entry for, telling you to go assign them in Spoolman and Refresh again.