### PR TITLE
Bambu: low-filament warnings, auto-pause, and fixed offline detection

### DIFF
--- a/bambu.go
+++ b/bambu.go
@@ -29,6 +29,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
@@ -42,6 +43,7 @@ const (
 	bambuConnectTimeout = 10 * time.Second
 	bambuKeepAlive      = 30 * time.Second
 	bambuFTPSTimeout    = 20 * time.Second
+	bambuCommandTimeout = 5 * time.Second // publish ack for pause/resume
 )
 
 // sliceInfoPath is the entry inside a Bambu .3mf (a zip) holding per-filament
@@ -90,6 +92,7 @@ type bambuClient struct {
 	accessCode string
 
 	client mqtt.Client
+	seq    atomic.Uint64 // sequence_id for outgoing commands
 
 	mu          sync.RWMutex
 	report      bambuReport
@@ -117,6 +120,10 @@ func newBambuClient(ip, serial, accessCode string) *bambuClient {
 	opts.SetOnConnectHandler(bc.onConnect)
 	opts.SetConnectionLostHandler(func(_ mqtt.Client, err error) {
 		log.Printf("Bambu %s: MQTT connection lost: %v", serial, err)
+		// Drop the cached report: whatever the printer was last doing is no
+		// longer something we know. onConnect re-requests a full state push, so
+		// the cache refills as soon as the printer is back.
+		bc.invalidateReport()
 	})
 
 	bc.client = mqtt.NewClient(opts)
@@ -155,6 +162,42 @@ func (bc *bambuClient) requestPushAll() {
 	bc.client.Publish(bc.requestTopic(), 0, false, payload)
 }
 
+// sendPrintCommand publishes a "print" command (pause/resume/stop) on the
+// printer's request topic. Bambu acknowledges nothing beyond the MQTT publish,
+// so the caller confirms the effect by watching gcode_state in the next report.
+func (bc *bambuClient) sendPrintCommand(command string) error {
+	// isConnected, not paho's IsConnected: a publish into a session that is only
+	// reconnecting would be reported as a successful pause that never happened.
+	if !bc.isConnected() {
+		return fmt.Errorf("MQTT not connected to %s", bc.ip)
+	}
+	payload := fmt.Sprintf(`{"print":{"sequence_id":"%d","command":"%s","param":""}}`,
+		bc.seq.Add(1), command)
+	token := bc.client.Publish(bc.requestTopic(), 0, false, payload)
+	if !token.WaitTimeout(bambuCommandTimeout) {
+		return fmt.Errorf("timed out publishing %q to %s", command, bc.ip)
+	}
+	return token.Error()
+}
+
+// PauseJob and ResumeJob satisfy jobController. Bambu's commands act on whatever
+// the printer is currently running rather than on a numbered job, so the job id
+// is accepted and ignored; it stays in the signature so a Bambu printer and a
+// PrusaLink one drive the same low-filament path.
+func (bc *bambuClient) PauseJob(int) error  { return bc.sendPrintCommand("pause") }
+func (bc *bambuClient) ResumeJob(int) error { return bc.sendPrintCommand("resume") }
+
+// IsPaused reports whether the printer is paused, from the cached MQTT state.
+// Unlike the PrusaLink implementation this costs the printer nothing, but it
+// needs at least one report to have arrived.
+func (bc *bambuClient) IsPaused() (bool, error) {
+	report, ok := bc.snapshot()
+	if !ok {
+		return false, fmt.Errorf("no state reported yet by %s", bc.ip)
+	}
+	return report.Print.GcodeState == bambuStatePause, nil
+}
+
 // bambuDebugRaw, when true, logs every raw MQTT report payload. Set by the
 // developer probe (main -bambu-probe) to inspect real printer messages.
 var bambuDebugRaw bool
@@ -183,8 +226,24 @@ func (bc *bambuClient) snapshot() (bambuReport, bool) {
 	return bc.report, bc.haveReport
 }
 
+// invalidateReport forgets the cached state, so a reader gets "nothing known"
+// rather than a report from before the printer went away.
+func (bc *bambuClient) invalidateReport() {
+	bc.mu.Lock()
+	defer bc.mu.Unlock()
+	bc.haveReport = false
+}
+
+// isConnected reports whether the MQTT session is actually open.
+//
+// It deliberately asks IsConnectionOpen rather than IsConnected: with
+// auto-reconnect and connect-retry both enabled (they are, above), paho's
+// IsConnected also answers true while it is merely *trying* to reconnect. A
+// printer that has been powered off would therefore read as connected forever,
+// and its last cached report would keep being served as current state.
+// IsConnectionOpen is true only for a live session.
 func (bc *bambuClient) isConnected() bool {
-	return bc.client.IsConnected()
+	return bc.client.IsConnectionOpen()
 }
 
 func (bc *bambuClient) disconnect() {
@@ -206,26 +265,92 @@ func bambuJobName(r bambuReport) string {
 // ensureBambuClient returns the persistent MQTT client for a printer, creating
 // and connecting it on first use. If the printer's address, serial, or access
 // code changed, the old client is torn down and replaced.
+//
+// The new client is registered before it is dialed, and the dial happens outside
+// bambuMutex: connect() blocks for up to bambuConnectTimeout, and holding the
+// map lock across it would serialize every other printer's setup behind an
+// unreachable one. A caller that arrives mid-dial gets the same client rather
+// than building a second connection to the same printer.
 func (b *FilamentBridge) ensureBambuClient(printerID string, config PrinterConfig) *bambuClient {
 	b.bambuMutex.Lock()
-	defer b.bambuMutex.Unlock()
-
 	if existing, ok := b.bambuClients[printerID]; ok {
 		if existing.ip == config.IPAddress && existing.serial == config.Serial && existing.accessCode == config.APIKey {
+			b.bambuMutex.Unlock()
 			return existing
 		}
 		existing.disconnect() // config changed; rebuild
 		delete(b.bambuClients, printerID)
 	}
-
 	bc := newBambuClient(config.IPAddress, config.Serial, config.APIKey)
 	b.bambuClients[printerID] = bc
+	b.bambuMutex.Unlock()
+
 	if err := bc.connect(); err != nil {
 		// Auto-reconnect keeps trying in the background; log and return the
 		// client so the next poll cycle sees it once it comes up.
 		log.Printf("Bambu %s: initial MQTT connect failed (will keep retrying): %v", config.Name, err)
 	}
 	return bc
+}
+
+// existingBambuClient returns the MQTT client already established for a printer,
+// or nil if none has been created. Unlike ensureBambuClient it never dials, so a
+// status read can consult live MQTT state without blocking on a TLS handshake.
+func (b *FilamentBridge) existingBambuClient(printerID string) *bambuClient {
+	b.bambuMutex.Lock()
+	defer b.bambuMutex.Unlock()
+	return b.bambuClients[printerID]
+}
+
+// StartBambuClients opens the MQTT connection for every configured Bambu printer
+// without waiting for a monitor cycle to do it. A Bambu printer has no status
+// endpoint to poll, so until its client is connected and has received a report
+// the dashboard has nothing to show but offline; starting the connections at
+// boot (and on every config reload) shrinks that window from a poll interval to
+// the length of one TLS handshake.
+//
+// Each printer connects in its own goroutine so an unreachable one cannot hold
+// up the others.
+func (b *FilamentBridge) StartBambuClients() {
+	cfg := b.GetConfigSnapshot()
+	if cfg == nil {
+		return
+	}
+	for printerID, pc := range cfg.Printers {
+		if printerID == "no_printers" || pc.Type != PrinterTypeBambu || pc.Serial == "" {
+			continue
+		}
+		go b.ensureBambuClient(printerID, pc)
+	}
+}
+
+// retireStaleBambuClients disconnects and drops the clients of printers that are
+// no longer configured (or are no longer Bambu printers), so a deleted printer
+// does not leave an MQTT session open for the life of the process. Printers
+// whose settings merely changed are rebuilt by ensureBambuClient.
+func (b *FilamentBridge) retireStaleBambuClients(printers map[string]PrinterConfig) {
+	b.bambuMutex.Lock()
+	defer b.bambuMutex.Unlock()
+
+	for printerID, bc := range b.bambuClients {
+		if pc, ok := printers[printerID]; ok && pc.Type == PrinterTypeBambu {
+			continue
+		}
+		bc.disconnect()
+		delete(b.bambuClients, printerID)
+		b.forgetPrinterStatus(printerID)
+	}
+}
+
+// CloseBambuClients disconnects every Bambu MQTT session, for shutdown.
+func (b *FilamentBridge) CloseBambuClients() {
+	b.bambuMutex.Lock()
+	defer b.bambuMutex.Unlock()
+
+	for printerID, bc := range b.bambuClients {
+		bc.disconnect()
+		delete(b.bambuClients, printerID)
+	}
 }
 
 // bambuStateIsPrinting reports whether the printer is actively working a job.
@@ -350,9 +475,13 @@ func (b *FilamentBridge) monitorBambu(printerID string, config PrinterConfig) er
 
 	report, ok := client.snapshot()
 	if !ok {
-		// Connected, awaiting the first report. Idle is the honest reading: the
-		// printer is reachable, we just do not know what it is doing yet.
-		b.cachePrinterStatus(printerID, StateIdle, nil)
+		// Session is open but the printer has not reported yet. Idle would be a
+		// guess, and a wrong guess here reads as "printer is fine and doing
+		// nothing" - which is indistinguishable from a printer that is actually
+		// gone. Offline is the honest answer for a state we do not know.
+		// onConnect requests a full state push, so this window closes as soon as
+		// the first report lands, well inside one poll interval.
+		b.cachePrinterStatus(printerID, StateOffline, nil)
 		return nil
 	}
 	p := report.Print
@@ -403,6 +532,11 @@ func (b *FilamentBridge) monitorBambu(printerID string, config PrinterConfig) er
 		if err := b.upsertActiveJob(aj); err != nil {
 			log.Printf("Warning: failed to persist active job for %s: %v", printerID, err)
 		}
+
+		// With the estimate in hand, warn (and optionally pause) if the mapped
+		// spool has less filament remaining than the print still needs. Same
+		// path PrusaLink uses; the MQTT client is the pauser here.
+		b.checkRunoutWarnings(printerID, config, client, aj)
 
 	case bambuStateIsTerminal(state) && active != nil && active.Filename != "":
 		completed := state == bambuStateFinish ||

--- a/bambu_test.go
+++ b/bambu_test.go
@@ -3,8 +3,13 @@ package main
 import (
 	"archive/zip"
 	"bytes"
+	"fmt"
+	"strings"
+	"sync"
 	"testing"
 	"time"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
 )
 
 // makeThreeMF wraps slice_info XML in a minimal .3mf (zip) for parser tests.
@@ -244,6 +249,404 @@ func TestBambuStatusComesFromCacheNotPrusaLink(t *testing.T) {
 	// The PrusaLink printer alongside it is still polled as usual.
 	if got := status.Printers["printer_test"].State; got != StateIdle {
 		t.Fatalf("PrusaLink printer state = %q, want %q", got, StateIdle)
+	}
+}
+
+// stubToken is an mqtt.Token that has already completed, carrying an optional
+// error, so publishes resolve synchronously in tests.
+type stubToken struct{ err error }
+
+func (t stubToken) Wait() bool                     { return true }
+func (t stubToken) WaitTimeout(time.Duration) bool { return true }
+func (t stubToken) Done() <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+func (t stubToken) Error() error { return t.err }
+
+// stubMQTT is an mqtt.Client standing in for a printer's broker: it reports
+// itself connected and records every publish, so command sending can be
+// exercised without a network.
+// The two connection predicates are modelled separately because paho draws the
+// same distinction: IsConnected is also true while merely reconnecting, and only
+// IsConnectionOpen means a live session.
+type stubMQTT struct {
+	mu         sync.Mutex
+	open       bool // a live session
+	retrying   bool // reconnect attempts in flight, nothing actually connected
+	publishErr error
+	topics     []string
+	payloads   []string
+}
+
+func (s *stubMQTT) IsConnected() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.open || s.retrying
+}
+func (s *stubMQTT) IsConnectionOpen() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.open
+}
+func (s *stubMQTT) Connect() mqtt.Token { return stubToken{} }
+func (s *stubMQTT) Disconnect(uint) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.open, s.retrying = false, false
+}
+
+// powerOff simulates the printer disappearing: paho keeps retrying in the
+// background, so it still calls itself "connected" while nothing is open.
+func (s *stubMQTT) powerOff() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.open, s.retrying = false, true
+}
+func (s *stubMQTT) Publish(topic string, _ byte, _ bool, payload interface{}) mqtt.Token {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.topics = append(s.topics, topic)
+	s.payloads = append(s.payloads, fmt.Sprint(payload))
+	return stubToken{err: s.publishErr}
+}
+func (s *stubMQTT) Subscribe(string, byte, mqtt.MessageHandler) mqtt.Token { return stubToken{} }
+func (s *stubMQTT) SubscribeMultiple(map[string]byte, mqtt.MessageHandler) mqtt.Token {
+	return stubToken{}
+}
+func (s *stubMQTT) Unsubscribe(...string) mqtt.Token        { return stubToken{} }
+func (s *stubMQTT) AddRoute(string, mqtt.MessageHandler)    {}
+func (s *stubMQTT) OptionsReader() mqtt.ClientOptionsReader { return mqtt.ClientOptionsReader{} }
+func (s *stubMQTT) sent() (topics []string, payloads []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.topics...), append([]string(nil), s.payloads...)
+}
+
+// stubBambuClient builds a bambuClient backed by a stub broker, already holding
+// the given gcode_state and sliced filename.
+func stubBambuClient(ip, serial, code, state, gcodeFile string) (*bambuClient, *stubMQTT) {
+	stub := &stubMQTT{open: true}
+	bc := &bambuClient{ip: ip, serial: serial, accessCode: code, client: stub}
+	bc.onMessage(nil, fakeMQTTMessage{[]byte(fmt.Sprintf(
+		`{"print":{"gcode_state":%q,"gcode_file":%q,"subtask_name":"bambu job","mc_percent":0}}`,
+		state, gcodeFile))})
+	return bc, stub
+}
+
+// bambuTestPrinter registers a Bambu printer on a test bridge alongside the
+// PrusaLink one, hands it a stubbed MQTT client, and returns both.
+func bambuTestPrinter(t *testing.T, b *FilamentBridge, state, gcodeFile string) (PrinterConfig, *stubMQTT) {
+	t.Helper()
+	const (
+		printerID = "printer_bambu"
+		ip        = "10.0.0.9"
+		serial    = "01S00A1234567890"
+		code      = "accesscode"
+	)
+	if err := b.SavePrinterConfig(printerID, PrinterConfig{
+		Name: "X1C", IPAddress: ip, APIKey: code, Toolheads: 4,
+		Type: PrinterTypeBambu, Serial: serial,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadConfig(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := b.UpdateConfig(cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	bc, stub := stubBambuClient(ip, serial, code, state, gcodeFile)
+	b.bambuMutex.Lock()
+	b.bambuClients[printerID] = bc
+	b.bambuMutex.Unlock()
+
+	return b.GetConfigSnapshot().Printers[printerID], stub
+}
+
+// TestBambuPrintCommands: pause and resume go out on the printer's request
+// topic with distinct sequence ids, and a disconnected client refuses to send
+// rather than reporting a pause that never happened.
+func TestBambuPrintCommands(t *testing.T) {
+	bc, stub := stubBambuClient("10.0.0.9", "SERIAL1", "code", bambuStateRunning, "part.3mf")
+
+	if err := bc.PauseJob(0); err != nil {
+		t.Fatalf("PauseJob: %v", err)
+	}
+	if err := bc.ResumeJob(0); err != nil {
+		t.Fatalf("ResumeJob: %v", err)
+	}
+
+	topics, payloads := stub.sent()
+	if len(payloads) != 2 {
+		t.Fatalf("expected 2 publishes, got %d: %v", len(payloads), payloads)
+	}
+	for _, topic := range topics {
+		if topic != "device/SERIAL1/request" {
+			t.Errorf("command sent to %q, want the request topic", topic)
+		}
+	}
+	if !strings.Contains(payloads[0], `"command":"pause"`) {
+		t.Errorf("pause payload = %s", payloads[0])
+	}
+	if !strings.Contains(payloads[1], `"command":"resume"`) {
+		t.Errorf("resume payload = %s", payloads[1])
+	}
+	if !strings.Contains(payloads[0], `"sequence_id":"1"`) || !strings.Contains(payloads[1], `"sequence_id":"2"`) {
+		t.Errorf("sequence ids must increment: %v", payloads)
+	}
+
+	// IsPaused reads the cached report, no round trip.
+	if paused, err := bc.IsPaused(); err != nil || paused {
+		t.Errorf("IsPaused while RUNNING = %v, %v", paused, err)
+	}
+	bc.onMessage(nil, fakeMQTTMessage{[]byte(`{"print":{"gcode_state":"PAUSE"}}`)})
+	if paused, err := bc.IsPaused(); err != nil || !paused {
+		t.Errorf("IsPaused while PAUSE = %v, %v", paused, err)
+	}
+
+	// A session that is only reconnecting must not report a pause it could not
+	// deliver, even though paho still calls itself connected.
+	stub.powerOff()
+	if err := bc.PauseJob(0); err == nil {
+		t.Error("a reconnecting client must not claim to have paused the print")
+	}
+	stub.Disconnect(0)
+	if err := bc.PauseJob(0); err == nil {
+		t.Error("a disconnected client must not claim to have paused the print")
+	}
+	if _, payloads := stub.sent(); len(payloads) != 2 {
+		t.Errorf("client with no live session still published: %v", payloads)
+	}
+}
+
+// TestBambuLowFilamentWarningAndPause: the low-filament path is shared with
+// PrusaLink, so a Bambu print whose mapped spool is short warns and (with the
+// opt-in on) auto-pauses over MQTT, and acknowledging resumes it.
+func TestBambuLowFilamentWarningAndPause(t *testing.T) {
+	printer := newFakePrusaLink(t)
+	spoolman := newFakeSpoolman(t)
+	spoolman.Spools[7] = &fakeSpool{ID: 7, Name: "Nearly Empty", RemainingWeight: 40}
+	b := newTestBridge(t, printer, spoolman)
+
+	const gcodeFile = "cache/part.gcode.3mf"
+	config, stub := bambuTestPrinter(t, b, bambuStateRunning, gcodeFile)
+	if err := b.SetToolheadMapping("X1C", 0, 7); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.SetConfigValue(ConfigKeyRunoutPauseEnabled, "true"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Seed the slicer estimate the way a previous cycle's FTPS fetch would, so
+	// the monitor has usage to compare without reaching for the printer.
+	if err := b.upsertActiveJob(&activeJob{
+		PrinterID: "printer_bambu", JobID: 4242, Filename: gcodeFile,
+		StartedAt: time.Now(), Usage: map[int]float64{0: 372.68},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := b.monitorBambu("printer_bambu", config); err != nil {
+		t.Fatalf("monitorBambu: %v", err)
+	}
+
+	warnings := b.GetRunoutWarnings()
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %+v", len(warnings), warnings)
+	}
+	w := warnings[0]
+	if w.SpoolID != 7 || w.RequiredWeight != 372.68 || w.RemainingWeight != 40 {
+		t.Errorf("warning fields: %+v", w)
+	}
+	if !w.AutoPaused {
+		t.Fatal("auto-pause is enabled but the warning did not record a pause")
+	}
+	if _, payloads := stub.sent(); len(payloads) != 1 || !strings.Contains(payloads[0], `"command":"pause"`) {
+		t.Fatalf("expected one pause command, got %v", payloads)
+	}
+
+	// The printer reports the pause; acknowledging the warning resumes it.
+	bc := b.existingBambuClient("printer_bambu")
+	bc.onMessage(nil, fakeMQTTMessage{[]byte(`{"print":{"gcode_state":"PAUSE"}}`)})
+	if err := b.AcknowledgeRunoutWarning(w.ID); err != nil {
+		t.Fatalf("acknowledge: %v", err)
+	}
+	_, payloads := stub.sent()
+	if len(payloads) != 2 || !strings.Contains(payloads[1], `"command":"resume"`) {
+		t.Fatalf("acknowledge did not resume: %v", payloads)
+	}
+
+	// A print the user already resumed at the printer is left alone.
+	bc.onMessage(nil, fakeMQTTMessage{[]byte(`{"print":{"gcode_state":"RUNNING"}}`)})
+	b.warnMutex.Lock()
+	w.Acknowledged = false
+	b.runoutWarnings[w.ID] = w
+	b.warnMutex.Unlock()
+	if err := b.AcknowledgeRunoutWarning(w.ID); err != nil {
+		t.Fatalf("second acknowledge: %v", err)
+	}
+	if _, payloads := stub.sent(); len(payloads) != 2 {
+		t.Errorf("resumed a print that was not paused: %v", payloads)
+	}
+}
+
+// TestBambuStatusBeforeFirstMonitorCycle: a Bambu printer has no endpoint to
+// poll, so with nothing in the status cache the dashboard reads its MQTT
+// client's own state rather than declaring the printer offline for a whole poll
+// interval. With no client, or a client that has not heard from the printer
+// yet, offline is still the honest answer.
+func TestBambuStatusBeforeFirstMonitorCycle(t *testing.T) {
+	printer := newFakePrusaLink(t)
+	spoolman := newFakeSpoolman(t)
+	b := newTestBridge(t, printer, spoolman)
+	config, _ := bambuTestPrinter(t, b, bambuStateRunning, "part.3mf")
+
+	bambuState := func(t *testing.T) string {
+		t.Helper()
+		status, err := b.GetStatus()
+		if err != nil {
+			t.Fatal(err)
+		}
+		return status.Printers["printer_bambu"].State
+	}
+
+	// Nothing cached, but the MQTT client is connected and has a report.
+	if got := bambuState(t); got != StatePrinting {
+		t.Errorf("state before first monitor cycle = %q, want %q", got, StatePrinting)
+	}
+
+	// A connected client that has not received a report yet stays offline.
+	b.forgetPrinterStatus("printer_bambu")
+	bare, _ := stubBambuClient(config.IPAddress, config.Serial, config.APIKey, "", "")
+	bare.mu.Lock()
+	bare.haveReport = false
+	bare.mu.Unlock()
+	b.bambuMutex.Lock()
+	b.bambuClients["printer_bambu"] = bare
+	b.bambuMutex.Unlock()
+	if got := bambuState(t); got != StateOffline {
+		t.Errorf("state with no report yet = %q, want %q", got, StateOffline)
+	}
+
+	// No client at all (web-only mode, printer never dialed): offline.
+	b.forgetPrinterStatus("printer_bambu")
+	b.bambuMutex.Lock()
+	delete(b.bambuClients, "printer_bambu")
+	b.bambuMutex.Unlock()
+	if got := bambuState(t); got != StateOffline {
+		t.Errorf("state with no MQTT client = %q, want %q", got, StateOffline)
+	}
+}
+
+// TestBambuPoweredOffPrinterReadsOffline: a printer that has been switched off
+// must read offline, not keep serving the state it was last seen in.
+//
+// paho, with auto-reconnect and connect-retry enabled, reports IsConnected true
+// while it is only *trying* to reconnect. Trusting that leaves a powered-off
+// printer looking connected forever, and monitorBambu then republishes its last
+// cached report - an A1 that was idle when unplugged stays "idle" on the
+// dashboard indefinitely.
+func TestBambuPoweredOffPrinterReadsOffline(t *testing.T) {
+	printer := newFakePrusaLink(t)
+	spoolman := newFakeSpoolman(t)
+	b := newTestBridge(t, printer, spoolman)
+	config, stub := bambuTestPrinter(t, b, bambuStateIdle, "")
+
+	if err := b.monitorBambu("printer_bambu", config); err != nil {
+		t.Fatalf("monitorBambu: %v", err)
+	}
+	if cached, fresh := b.cachedPrinterState("printer_bambu"); !fresh || cached.state != StateIdle {
+		t.Fatalf("connected printer should read idle, got %q (fresh=%v)", cached.state, fresh)
+	}
+
+	// Printer unplugged. paho still calls itself connected while retrying.
+	stub.powerOff()
+	if !stub.IsConnected() {
+		t.Fatal("test premise wrong: paho reports connected while reconnecting")
+	}
+
+	if err := b.monitorBambu("printer_bambu", config); err != nil {
+		t.Fatalf("monitorBambu after power off: %v", err)
+	}
+	cached, fresh := b.cachedPrinterState("printer_bambu")
+	if !fresh || cached.state != StateOffline {
+		t.Errorf("powered-off printer state = %q (fresh=%v), want %q", cached.state, fresh, StateOffline)
+	}
+
+	// And the dashboard agrees, rather than serving the pre-drop report.
+	status, err := b.GetStatus()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := status.Printers["printer_bambu"].State; got != StateOffline {
+		t.Errorf("dashboard state for powered-off printer = %q, want %q", got, StateOffline)
+	}
+}
+
+// TestBambuUnreportedPrinterReadsOffline covers the case that bites on startup
+// with the printer switched off: paho's retry loop leaves the client claiming to
+// be connected, no report ever arrives, and the state is simply unknown. Idle
+// would be a guess that reads as a healthy, unused printer - offline is the
+// honest answer for a printer that has told us nothing.
+func TestBambuUnreportedPrinterReadsOffline(t *testing.T) {
+	printer := newFakePrusaLink(t)
+	spoolman := newFakeSpoolman(t)
+	b := newTestBridge(t, printer, spoolman)
+	config, _ := bambuTestPrinter(t, b, bambuStateIdle, "")
+
+	// Live session, but the printer has not reported yet.
+	b.existingBambuClient("printer_bambu").invalidateReport()
+
+	if err := b.monitorBambu("printer_bambu", config); err != nil {
+		t.Fatalf("monitorBambu: %v", err)
+	}
+	cached, fresh := b.cachedPrinterState("printer_bambu")
+	if !fresh || cached.state != StateOffline {
+		t.Errorf("state with no report = %q (fresh=%v), want %q", cached.state, fresh, StateOffline)
+	}
+}
+
+// TestBambuReportInvalidatedOnConnectionLoss: once the session drops, the
+// cached report is no longer evidence of anything, so a reconnect serves fresh
+// state rather than what the printer was doing before it vanished.
+func TestBambuReportInvalidatedOnConnectionLoss(t *testing.T) {
+	bc, _ := stubBambuClient("10.0.0.9", "SERIAL1", "code", bambuStateRunning, "part.3mf")
+	if _, ok := bc.snapshot(); !ok {
+		t.Fatal("setup should have left a report cached")
+	}
+
+	bc.invalidateReport()
+
+	if _, ok := bc.snapshot(); ok {
+		t.Error("report survived the connection loss")
+	}
+}
+
+// TestRetireStaleBambuClients: deleting a Bambu printer must close its MQTT
+// session instead of leaving it open for the life of the process.
+func TestRetireStaleBambuClients(t *testing.T) {
+	printer := newFakePrusaLink(t)
+	spoolman := newFakeSpoolman(t)
+	b := newTestBridge(t, printer, spoolman)
+	bambuTestPrinter(t, b, bambuStateRunning, "part.3mf")
+
+	bc := b.existingBambuClient("printer_bambu")
+	if bc == nil {
+		t.Fatal("test setup did not register a Bambu client")
+	}
+
+	// Config no longer lists the printer.
+	b.retireStaleBambuClients(map[string]PrinterConfig{})
+
+	if b.existingBambuClient("printer_bambu") != nil {
+		t.Error("client for a deleted printer was kept")
+	}
+	if bc.isConnected() {
+		t.Error("client for a deleted printer was left connected")
 	}
 }
 

--- a/bridge.go
+++ b/bridge.go
@@ -549,6 +549,34 @@ func (b *FilamentBridge) GetRunoutWarnings() []RunoutWarning {
 	return warnings
 }
 
+// jobController is the printer control surface the low-filament path needs:
+// pause a running print, resume it, and tell whether it is currently paused.
+// PrusaLink drives it over HTTP and Bambu over MQTT, so the warning logic below
+// is written once against the interface instead of once per printer type.
+type jobController interface {
+	PauseJob(jobID int) error
+	ResumeJob(jobID int) error
+	IsPaused() (bool, error)
+}
+
+var (
+	_ jobController = (*PrusaLinkClient)(nil)
+	_ jobController = (*bambuClient)(nil)
+)
+
+// jobControllerFor returns the pause/resume controller for a printer, chosen by
+// its type. It returns nil when a Bambu printer has no MQTT client yet, which
+// leaves auto-pause off for that cycle rather than misreporting a pause.
+func (b *FilamentBridge) jobControllerFor(printerID string, pc PrinterConfig, cfg *Config) jobController {
+	if pc.Type == PrinterTypeBambu {
+		if bc := b.existingBambuClient(printerID); bc != nil {
+			return bc
+		}
+		return nil
+	}
+	return b.prusaClientFor(printerID, pc, cfg)
+}
+
 // AcknowledgeRunoutWarning dismisses a low-filament warning. If the warning
 // auto-paused the print and the printer is still paused, the print is resumed
 // first; a print the user already resumed at the printer is left alone.
@@ -564,13 +592,16 @@ func (b *FilamentBridge) AcknowledgeRunoutWarning(id string) error {
 		cfg := b.GetConfigSnapshot()
 		if cfg != nil {
 			if pc, ok := cfg.Printers[w.PrinterID]; ok {
-				client := b.prusaClientFor(w.PrinterID, pc, cfg)
-				status, err := client.GetStatus()
+				controller := b.jobControllerFor(w.PrinterID, pc, cfg)
+				if controller == nil {
+					return fmt.Errorf("no connection to %s to resume the print", w.PrinterName)
+				}
+				paused, err := controller.IsPaused()
 				if err != nil {
 					return fmt.Errorf("could not check printer state before resuming: %w", err)
 				}
-				if status.Printer.State == StatePaused {
-					if err := client.ResumeJob(w.JobID); err != nil {
+				if paused {
+					if err := controller.ResumeJob(w.JobID); err != nil {
 						return fmt.Errorf("failed to resume print: %w", err)
 					}
 					log.Printf("Resumed job %d on %s after low-filament warning was acknowledged", w.JobID, w.PrinterName)
@@ -599,7 +630,10 @@ const runoutCheckDone = 1000
 // (optionally pausing the print) when the spool will run short. Each
 // (job, toolhead, spool) combination is checked once; remapping a toolhead to
 // a different spool triggers a fresh check.
-func (b *FilamentBridge) checkRunoutWarnings(printerID string, config PrinterConfig, client *PrusaLinkClient, aj *activeJob) {
+//
+// controller pauses the print when auto-pause is on; it is shared by both
+// printer backends, and a nil one means "warn only" for this cycle.
+func (b *FilamentBridge) checkRunoutWarnings(printerID string, config PrinterConfig, controller jobController, aj *activeJob) {
 	if len(aj.Usage) == 0 {
 		return
 	}
@@ -647,8 +681,8 @@ func (b *FilamentBridge) checkRunoutWarnings(printerID string, config PrinterCon
 		}
 
 		autoPaused := false
-		if pauseEnabled, err := b.GetRunoutPauseEnabled(); err == nil && pauseEnabled && aj.JobID != 0 {
-			if err := client.PauseJob(aj.JobID); err != nil {
+		if pauseEnabled, err := b.GetRunoutPauseEnabled(); err == nil && pauseEnabled && aj.JobID != 0 && controller != nil {
+			if err := controller.PauseJob(aj.JobID); err != nil {
 				log.Printf("Warning: could not pause job %d after low-filament warning: %v", aj.JobID, err)
 			} else {
 				autoPaused = true
@@ -958,6 +992,10 @@ func (b *FilamentBridge) ReloadConfig() error {
 	// whose settings changed are rebuilt lazily by prusaClientFor, which also
 	// closes the client it replaces.
 	b.retireStalePrusaClients(config.Printers)
+	b.retireStaleBambuClients(config.Printers)
+	// Connect any newly configured Bambu printer now rather than at the next
+	// poll, so a printer added from the UI does not read offline in between.
+	b.StartBambuClients()
 
 	return nil
 }
@@ -2228,14 +2266,25 @@ func (b *FilamentBridge) GetStatus() (*PrinterStatus, error) {
 			}
 
 			// A Bambu printer has no PrusaLink status endpoint to poll: its state
-			// only ever arrives through the monitor's MQTT client, which caches it
-			// above. With nothing cached yet (monitor has not run, or web-only
-			// mode) the honest answer is offline rather than a failed HTTP poll
-			// against a printer that does not serve one.
+			// arrives over MQTT. With nothing in the status cache yet (the first
+			// monitor cycle has not landed, or web-only mode), read the MQTT
+			// client's own cache directly - that is the Bambu equivalent of the
+			// live poll the PrusaLink branch does below, and it is what keeps a
+			// just-started printer from reading offline for a whole poll
+			// interval. Only an already-established client is consulted:
+			// StartBambuClients dials at boot and on config reload, so a
+			// dashboard load never has to wait on a TLS handshake.
 			if printerConfig.Type == PrinterTypeBambu {
+				state := StateOffline
+				if bc := b.existingBambuClient(printerID); bc != nil && bc.isConnected() {
+					if report, ok := bc.snapshot(); ok {
+						state = bambuDashboardState(report.Print.GcodeState)
+						b.cachePrinterStatus(printerID, state, nil)
+					}
+				}
 				status.Printers[printerID] = PrinterData{
 					Name:  printerName,
-					State: StateOffline,
+					State: state,
 				}
 				continue
 			}
@@ -2378,6 +2427,7 @@ func (b *FilamentBridge) processFilamentUsage(printerName string, filamentUsage 
 func (b *FilamentBridge) Close() error {
 	// Hand the printers their sockets back before going away.
 	b.ClosePrusaClients()
+	b.CloseBambuClients()
 	if b.db != nil {
 		return b.db.Close()
 	}

--- a/main.go
+++ b/main.go
@@ -76,6 +76,11 @@ func main() {
 		log.Fatalf("Failed to update bridge config: %v", err)
 	}
 
+	// Bring up the Bambu MQTT sessions now. They are the only source of state
+	// for those printers, so waiting for the first monitor cycle would leave
+	// them reading offline on the dashboard until then.
+	bridge.StartBambuClients()
+
 	// Override port from config if not specified
 	if *port == DefaultWebPort && config.WebPort != DefaultWebPort {
 		*port = config.WebPort

--- a/prusalink.go
+++ b/prusalink.go
@@ -216,6 +216,17 @@ func (c *PrusaLinkClient) ResumeJob(jobID int) error {
 	return c.jobCommand(jobID, "resume")
 }
 
+// IsPaused reports whether the printer is currently paused, so a caller can tell
+// an auto-paused print from one the user already resumed at the printer. It
+// completes the jobController interface alongside PauseJob and ResumeJob.
+func (c *PrusaLinkClient) IsPaused() (bool, error) {
+	status, err := c.GetStatus()
+	if err != nil {
+		return false, err
+	}
+	return status.Printer.State == StatePaused, nil
+}
+
 // GetGcodeFileWithRetry downloads the G-code file with retry logic and exponential backoff
 func (c *PrusaLinkClient) GetGcodeFileWithRetry(filename string, fileDownloadTimeout int) ([]byte, error) {
 	backoffDelays := []time.Duration{2 * time.Second, 4 * time.Second, 8 * time.Second}


### PR DESCRIPTION
Closes two of the previously documented Bambu gaps and fixes a state-reporting bug found while testing them.

- Low filament warnings and auto-pause now work for Bambu printers. The warning logic moved onto a small jobController interface (pause, resume, is-paused) that both backends implement, driven over HTTP for PrusaLink and MQTT for Bambu.

- Bambu MQTT sessions now open at boot and on config reload, and a cold dashboard read consults the MQTT client directly, so a printer no longer reads offline for a poll interval after startup.

- Fix a powered-off printer reporting its last known state forever. IsConnected is also true while merely reconnecting, so connectivity now asks IsConnectionOpen and the cached report is dropped on connection loss. The startup variant of the same bug reported IDLE when the client had never connected, so unknown state now reports offline instead of guessing.

- ensureBambuClient dials outside the map lock so one unreachable printer cannot serialize the others, and Bambu clients are retired on printer deletion and disconnected on shutdown.