### PR TITLE
fix(spoolman): follow v0.26's location model - list-only, working rename, toolhead overlay

### DIFF
--- a/spoolman.go
+++ b/spoolman.go
@@ -270,28 +270,40 @@ func (c *SpoolmanClient) GetAllFilaments() ([]SpoolmanFilament, error) {
 // the Spoolman base URL) and verifies a 200 response. opDesc names the
 // operation for error messages, e.g. "updating spool 3".
 func (c *SpoolmanClient) patchJSON(path string, data map[string]interface{}, opDesc string) error {
+	_, err := c.patchJSONResult(path, data, opDesc)
+	return err
+}
+
+// patchJSONResult is patchJSON for the few endpoints whose response body carries
+// information we act on (e.g. the bulk field update's spools_updated count).
+func (c *SpoolmanClient) patchJSONResult(path string, data map[string]interface{}, opDesc string) ([]byte, error) {
 	jsonData, err := json.Marshal(data)
 	if err != nil {
-		return fmt.Errorf("error marshaling data for %s: %w", opDesc, err)
+		return nil, fmt.Errorf("error marshaling data for %s: %w", opDesc, err)
 	}
 
 	req, err := http.NewRequest("PATCH", c.baseURL+path, bytes.NewBuffer(jsonData))
 	if err != nil {
-		return fmt.Errorf("error creating PATCH request: %w", err)
+		return nil, fmt.Errorf("error creating PATCH request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	c.addAuthHeader(req)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("error %s in Spoolman: %w", opDesc, err)
+		return nil, fmt.Errorf("error %s in Spoolman: %w", opDesc, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return c.handleAPIError(resp)
+		return nil, c.handleAPIError(resp)
 	}
-	return nil
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response for %s: %w", opDesc, err)
+	}
+	return body, nil
 }
 
 // UpdateSpool updates spool information (used for filament usage tracking)
@@ -388,76 +400,27 @@ type SpoolmanLocation struct {
 	Archived bool   `json:"archived"`
 }
 
-// GetLocations returns Spoolman's locations, merged from both sources so that
-// upgraded instances don't lose data. The `locations` setting holds predefined
-// locations (including empty ones, created via older clients), while
-// /api/v1/location reports locations currently referenced by spools (the only
-// place new v0.26 client locations show up). Results are unioned and deduped by
-// exact name; empty/whitespace names are skipped.
+// GetLocations returns Spoolman's locations as reported by /api/v1/location,
+// i.e. the distinct location strings currently referenced by spools. This
+// mirrors what the Spoolman v0.26 UI itself shows: locations are just strings
+// on spools, not first-class entities. The legacy `locations` setting is
+// intentionally ignored — v0.26 no longer reads or writes it, so any
+// predefined, spool-less entries there are invisible in Spoolman too.
 func (c *SpoolmanClient) GetLocations() ([]SpoolmanLocation, error) {
-	settingLocs, settingErr := c.getLocationsFromSetting()
-	listLocs, listErr := c.getLocationsFromList()
-
-	// Only fail if BOTH sources errored — a single working source is still useful.
-	if settingErr != nil && listErr != nil {
-		return nil, fmt.Errorf("failed to get locations from Spoolman (setting: %v; list: %w)", settingErr, listErr)
+	listLocs, err := c.getLocationsFromList()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get locations from Spoolman: %w", err)
 	}
 
-	merged := make([]SpoolmanLocation, 0, len(settingLocs)+len(listLocs))
-	seen := make(map[string]bool)
-	// Setting first so its metadata (ID/comment/archived) wins for shared names.
-	for _, loc := range append(settingLocs, listLocs...) {
-		if strings.TrimSpace(loc.Name) == "" {
-			continue
-		}
-		if seen[loc.Name] {
-			continue
-		}
-		seen[loc.Name] = true
-		merged = append(merged, loc)
-	}
-	return merged, nil
+	return listLocs, nil
 }
 
-// getLocationsFromSetting reads the predefined location list from Spoolman's
-// `locations` setting, whose value is a JSON-encoded array of names.
-func (c *SpoolmanClient) getLocationsFromSetting() ([]SpoolmanLocation, error) {
-	req, err := http.NewRequest("GET", c.baseURL+"/api/v1/setting/locations", nil)
-	if err != nil {
-		return nil, err
-	}
-	c.addAuthHeader(req)
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("spoolman setting/locations returned HTTP %d", resp.StatusCode)
-	}
-	var setting struct {
-		Value string `json:"value"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&setting); err != nil {
-		return nil, err
-	}
-	var names []string
-	if strings.TrimSpace(setting.Value) != "" {
-		if err := json.Unmarshal([]byte(setting.Value), &names); err != nil {
-			return nil, fmt.Errorf("parsing locations setting value: %w", err)
-		}
-	}
-	locations := make([]SpoolmanLocation, 0, len(names))
-	for _, n := range names {
-		if strings.TrimSpace(n) != "" {
-			locations = append(locations, SpoolmanLocation{Name: n})
-		}
-	}
-	return locations, nil
-}
-
-// getLocationsFromList reads locations from /api/v1/location — only those that
-// currently hold a spool. Fallback for Spoolman without the locations setting.
+// getLocationsFromList reads locations from Spoolman's GET /api/v1/location.
+// The endpoint's response shape has varied across Spoolman versions, so we try
+// several: an array of objects, a {data|results:[...]} wrapper, and a plain
+// array of name strings (v0.26). Whichever parses, the names are normalized in
+// one place: blank/whitespace names become "Unassigned", mirroring Spoolman's
+// UI, which groups spool-less/empty locations under that label.
 func (c *SpoolmanClient) getLocationsFromList() ([]SpoolmanLocation, error) {
 	req, err := http.NewRequest("GET", c.baseURL+"/api/v1/location", nil)
 	if err != nil {
@@ -475,48 +438,74 @@ func (c *SpoolmanClient) getLocationsFromList() ([]SpoolmanLocation, error) {
 		return nil, c.handleAPIError(resp)
 	}
 
-	// Read full body so we can retry alternative shapes and log on error
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading locations response from Spoolman: %w", err)
 	}
 
-	// 1) Try standard array of objects
 	var locations []SpoolmanLocation
+	parsed := false
+
+	// 1) Standard array of objects: [{"name":"...","id":1,...}, ...]
 	if err := json.Unmarshal(bodyBytes, &locations); err == nil {
-		return locations, nil
+		parsed = true
 	}
 
-	// 2) Try { data: [...] } wrapper
-	var dataWrapper struct {
-		Data    []SpoolmanLocation `json:"data"`
-		Results []SpoolmanLocation `json:"results"`
-	}
-	if err := json.Unmarshal(bodyBytes, &dataWrapper); err == nil {
-		if len(dataWrapper.Data) > 0 {
-			return dataWrapper.Data, nil
+	// 2) Wrapped: {"data":[...]} or {"results":[...]}
+	if !parsed {
+		var wrapper struct {
+			Data    []SpoolmanLocation `json:"data"`
+			Results []SpoolmanLocation `json:"results"`
 		}
-		if len(dataWrapper.Results) > 0 {
-			return dataWrapper.Results, nil
+		if err := json.Unmarshal(bodyBytes, &wrapper); err == nil {
+			switch {
+			case len(wrapper.Data) > 0:
+				locations = wrapper.Data
+				parsed = true
+			case len(wrapper.Results) > 0:
+				locations = wrapper.Results
+				parsed = true
+			}
 		}
 	}
 
-	// 3) Try simple array of names like ["Testing", ...]
-	var names []string
-	if err := json.Unmarshal(bodyBytes, &names); err == nil {
-		for _, n := range names {
-			locations = append(locations, SpoolmanLocation{Name: n})
+	// 3) Plain array of names: ["Closet Shelf", "", ...] (Spoolman v0.26)
+	if !parsed {
+		var names []string
+		if err := json.Unmarshal(bodyBytes, &names); err == nil {
+			locations = make([]SpoolmanLocation, 0, len(names))
+			for _, n := range names {
+				locations = append(locations, SpoolmanLocation{Name: n})
+			}
+			parsed = true
 		}
-		return locations, nil
 	}
 
-	// Log snippet for diagnostics and return error
-	snippet := string(bodyBytes)
-	if len(snippet) > 300 {
-		snippet = snippet[:300] + "..."
+	if !parsed {
+		snippet := string(bodyBytes)
+		if len(snippet) > 300 {
+			snippet = snippet[:300] + "..."
+		}
+		log.Printf("Spoolman /location unexpected JSON. Snippet: %s", snippet)
+		return nil, fmt.Errorf("error decoding locations from Spoolman: unexpected JSON shape")
 	}
-	log.Printf("Spoolman /location unexpected JSON. Snippet: %s", snippet)
-	return nil, fmt.Errorf("error decoding locations from Spoolman: unexpected JSON shape")
+
+	// Single normalization pass, applied no matter which shape parsed:
+	// blank names -> "Unassigned", and dedupe by final name so an "" and a
+	// literal "Unassigned" (or two blanks) don't produce duplicates.
+	normalized := make([]SpoolmanLocation, 0, len(locations))
+	seen := make(map[string]bool)
+	for _, loc := range locations {
+		if strings.TrimSpace(loc.Name) == "" {
+			loc.Name = "Unassigned"
+		}
+		if seen[loc.Name] {
+			continue
+		}
+		seen[loc.Name] = true
+		normalized = append(normalized, loc)
+	}
+	return normalized, nil
 }
 
 // GetOrCreateLocation gets an existing location by name
@@ -575,40 +564,46 @@ func (c *SpoolmanClient) UpdateSpoolLocation(spoolID int, locationName string) e
 	return nil
 }
 
-// UpdateLocation updates a location name in Spoolman
-func (c *SpoolmanClient) UpdateLocation(locationID int, newName string) error {
-	err := c.patchJSON(fmt.Sprintf("/api/v1/location/%d", locationID),
-		map[string]interface{}{"name": newName},
-		fmt.Sprintf("updating location %d", locationID))
+// UpdateLocationByName renames a location by rewriting the `location` string on
+// every spool that currently carries oldName. This mirrors Spoolman's own
+// dashboard group-rename (PATCH /api/v1/spool/field/location): locations are
+// just strings on spools, not first-class entities, so a rename is a bulk
+// field update.
+func (c *SpoolmanClient) UpdateLocationByName(oldName, newName string) error {
+	// Keep the caller's spelling for logs and errors; the wire values below are
+	// the mapped ones.
+	displayOld, displayNew := oldName, newName
+
+	// Map the UI's "Unassigned" back to the empty string Spoolman stores.
+	if oldName == "Unassigned" {
+		oldName = ""
+	}
+	if newName == "Unassigned" {
+		newName = ""
+	}
+
+	body, err := c.patchJSONResult("/api/v1/spool/field/location",
+		map[string]interface{}{"value": oldName, "new_value": newName},
+		fmt.Sprintf("renaming location '%s' to '%s'", displayOld, displayNew))
 	if err != nil {
 		return err
 	}
-	log.Printf("Successfully updated Spoolman location %d to '%s'", locationID, newName)
+
+	// Spoolman answers 200 with a count even when the old name matched nothing.
+	// A rename that moved no spools changed nothing, so report it rather than
+	// telling the user it worked.
+	var result struct {
+		SpoolsUpdated *int `json:"spools_updated"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		// Unrecognized shape: the PATCH itself succeeded, so don't fail the rename.
+		log.Printf("Warning: could not parse rename response for location '%s': %v", displayOld, err)
+		return nil
+	}
+	if result.SpoolsUpdated != nil && *result.SpoolsUpdated == 0 {
+		return fmt.Errorf("no spools are in location '%s'", displayOld)
+	}
+
+	log.Printf("Successfully renamed Spoolman location '%s' to '%s'", displayOld, displayNew)
 	return nil
-}
-
-// UpdateLocationByName updates a location in Spoolman by name
-func (c *SpoolmanClient) UpdateLocationByName(oldName, newName string) error {
-	// First, find the location by name
-	locations, err := c.GetLocations()
-	if err != nil {
-		return fmt.Errorf("failed to get locations: %w", err)
-	}
-
-	var locationID int
-	found := false
-	for _, loc := range locations {
-		if loc.Name == oldName && !loc.Archived {
-			locationID = loc.ID
-			found = true
-			break
-		}
-	}
-
-	if !found {
-		return fmt.Errorf("location '%s' not found in Spoolman", oldName)
-	}
-
-	// Update the location using its ID
-	return c.UpdateLocation(locationID, newName)
 }

--- a/spoolman.go
+++ b/spoolman.go
@@ -388,15 +388,35 @@ type SpoolmanLocation struct {
 	Archived bool   `json:"archived"`
 }
 
-// GetLocations returns Spoolman's predefined locations. It prefers the
-// `locations` setting, which lists ALL created locations (including empty ones);
-// older Spoolman versions without that setting fall back to the /location list,
-// which only reports locations that currently hold a spool.
+// GetLocations returns Spoolman's locations, merged from both sources so that
+// upgraded instances don't lose data. The `locations` setting holds predefined
+// locations (including empty ones, created via older clients), while
+// /api/v1/location reports locations currently referenced by spools (the only
+// place new v0.26 client locations show up). Results are unioned and deduped by
+// exact name; empty/whitespace names are skipped.
 func (c *SpoolmanClient) GetLocations() ([]SpoolmanLocation, error) {
-	if locs, err := c.getLocationsFromSetting(); err == nil {
-		return locs, nil
+	settingLocs, settingErr := c.getLocationsFromSetting()
+	listLocs, listErr := c.getLocationsFromList()
+
+	// Only fail if BOTH sources errored — a single working source is still useful.
+	if settingErr != nil && listErr != nil {
+		return nil, fmt.Errorf("failed to get locations from Spoolman (setting: %v; list: %w)", settingErr, listErr)
 	}
-	return c.getLocationsFromList()
+
+	merged := make([]SpoolmanLocation, 0, len(settingLocs)+len(listLocs))
+	seen := make(map[string]bool)
+	// Setting first so its metadata (ID/comment/archived) wins for shared names.
+	for _, loc := range append(settingLocs, listLocs...) {
+		if strings.TrimSpace(loc.Name) == "" {
+			continue
+		}
+		if seen[loc.Name] {
+			continue
+		}
+		seen[loc.Name] = true
+		merged = append(merged, loc)
+	}
+	return merged, nil
 }
 
 // getLocationsFromSetting reads the predefined location list from Spoolman's

--- a/spoolman_test.go
+++ b/spoolman_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"sort"
+	"testing"
+)
+
+// namesOf extracts the Name field from each location, sorted, for
+// order-independent comparison.
+func namesOf(locs []SpoolmanLocation) []string {
+	out := make([]string, 0, len(locs))
+	for _, l := range locs {
+		out = append(out, l.Name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestGetLocations(t *testing.T) {
+	cases := []struct {
+		name      string
+		locations []string // served at /api/v1/location
+		setting   []string // nil => setting endpoint 404s
+		want      []string
+	}{
+		{
+			name:      "empty setting falls through to list",
+			locations: []string{"Closet Shelf", "Printer A"},
+			setting:   []string{}, // set but empty
+			want:      []string{"Closet Shelf", "Printer A"},
+		},
+		{
+			name:      "setting endpoint 404s, list still used",
+			locations: []string{"Closet Shelf", "Printer A"},
+			setting:   nil, // nil => 404 => setting source errors
+			want:      []string{"Closet Shelf", "Printer A"},
+		},
+		{
+			name:      "union and dedupe by exact name",
+			locations: []string{"Closet Shelf", "Printer A"},
+			setting:   []string{"Closet Shelf", "Bin 3"},
+			want:      []string{"Bin 3", "Closet Shelf", "Printer A"}, // "Closet Shelf" once
+		},
+		{
+			name:      "empty and whitespace names are skipped",
+			locations: []string{"Printer A", "", "   "},
+			setting:   []string{"Bin 3", ""},
+			want:      []string{"Bin 3", "Printer A"},
+		},
+		{
+			name:      "setting only (list empty)",
+			locations: []string{},
+			setting:   []string{"Bin 3", "Closet Shelf"},
+			want:      []string{"Bin 3", "Closet Shelf"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newFakeSpoolman(t)
+			srv.Locations = tc.locations
+			srv.LocationSetting = tc.setting
+
+			client := NewSpoolmanClient(srv.URL(), 5, "", "")
+			got, err := client.GetLocations()
+			if err != nil {
+				t.Fatalf("GetLocations returned error: %v", err)
+			}
+
+			gotNames := namesOf(got)
+			want := append([]string(nil), tc.want...)
+			sort.Strings(want)
+
+			if len(gotNames) != len(want) {
+				t.Fatalf("got %v, want %v", gotNames, want)
+			}
+			for i := range gotNames {
+				if gotNames[i] != want[i] {
+					t.Fatalf("got %v, want %v", gotNames, want)
+				}
+			}
+		})
+	}
+}

--- a/spoolman_test.go
+++ b/spoolman_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
 	"sort"
 	"testing"
 )
@@ -17,68 +20,189 @@ func namesOf(locs []SpoolmanLocation) []string {
 }
 
 func TestGetLocations(t *testing.T) {
+	srv := newFakeSpoolman(t)
+	srv.Locations = []string{"Closet Shelf", "", "Printer A"}
+
+	client := NewSpoolmanClient(srv.URL(), 5, "", "")
+	got, err := client.GetLocations()
+	if err != nil {
+		t.Fatalf("GetLocations returned error: %v", err)
+	}
+
+	want := []string{"Closet Shelf", "Printer A", "Unassigned"}
+	gotNames := namesOf(got)
+	sort.Strings(want)
+	if !reflect.DeepEqual(gotNames, want) {
+		t.Fatalf("got %v, want %v", gotNames, want)
+	}
+}
+
+// TestGetLocationsFromList pins the response shapes we accept from
+// GET /api/v1/location and the single normalization pass applied to all of
+// them: blank names become "Unassigned" (mirroring Spoolman's own UI) and the
+// result is deduped by final name.
+func TestGetLocationsFromList(t *testing.T) {
 	cases := []struct {
-		name      string
-		locations []string // served at /api/v1/location
-		setting   []string // nil => setting endpoint 404s
-		want      []string
+		name string
+		body string
+		want []string
 	}{
 		{
-			name:      "empty setting falls through to list",
-			locations: []string{"Closet Shelf", "Printer A"},
-			setting:   []string{}, // set but empty
-			want:      []string{"Closet Shelf", "Printer A"},
+			name: "array of objects",
+			body: `[{"id":1,"name":"Closet Shelf"},{"id":2,"name":"Printer A"}]`,
+			want: []string{"Closet Shelf", "Printer A"},
 		},
 		{
-			name:      "setting endpoint 404s, list still used",
-			locations: []string{"Closet Shelf", "Printer A"},
-			setting:   nil, // nil => 404 => setting source errors
-			want:      []string{"Closet Shelf", "Printer A"},
+			name: "data wrapper",
+			body: `{"data":[{"id":1,"name":"Closet Shelf"}]}`,
+			want: []string{"Closet Shelf"},
 		},
 		{
-			name:      "union and dedupe by exact name",
-			locations: []string{"Closet Shelf", "Printer A"},
-			setting:   []string{"Closet Shelf", "Bin 3"},
-			want:      []string{"Bin 3", "Closet Shelf", "Printer A"}, // "Closet Shelf" once
+			name: "results wrapper",
+			body: `{"results":[{"id":1,"name":"Printer A"}]}`,
+			want: []string{"Printer A"},
 		},
 		{
-			name:      "empty and whitespace names are skipped",
-			locations: []string{"Printer A", "", "   "},
-			setting:   []string{"Bin 3", ""},
-			want:      []string{"Bin 3", "Printer A"},
+			name: "plain array of names",
+			body: `["Closet Shelf","Printer A"]`,
+			want: []string{"Closet Shelf", "Printer A"},
 		},
 		{
-			name:      "setting only (list empty)",
-			locations: []string{},
-			setting:   []string{"Bin 3", "Closet Shelf"},
-			want:      []string{"Bin 3", "Closet Shelf"},
+			name: "blank name normalizes to Unassigned",
+			body: `[{"id":1,"name":""},{"id":2,"name":"Printer A"}]`,
+			want: []string{"Printer A", "Unassigned"},
+		},
+		{
+			name: "whitespace-only name normalizes to Unassigned",
+			body: `["   ","Printer A"]`,
+			want: []string{"Printer A", "Unassigned"},
+		},
+		{
+			name: "multiple blanks collapse to one Unassigned",
+			body: `[{"id":1,"name":""},{"id":2,"name":"  "},{"id":3,"name":"Printer A"}]`,
+			want: []string{"Printer A", "Unassigned"},
+		},
+		{
+			name: "blank and literal Unassigned do not duplicate",
+			body: `["","Unassigned","Printer A"]`,
+			want: []string{"Printer A", "Unassigned"},
+		},
+		{
+			name: "duplicate names deduped",
+			body: `["Printer A","Printer A"]`,
+			want: []string{"Printer A"},
+		},
+		{
+			name: "empty list",
+			body: `[]`,
+			want: []string{},
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			srv := newFakeSpoolman(t)
-			srv.Locations = tc.locations
-			srv.LocationSetting = tc.setting
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
 
-			client := NewSpoolmanClient(srv.URL(), 5, "", "")
-			got, err := client.GetLocations()
+			client := NewSpoolmanClient(srv.URL, 5, "", "")
+			got, err := client.getLocationsFromList()
 			if err != nil {
-				t.Fatalf("GetLocations returned error: %v", err)
+				t.Fatalf("getLocationsFromList error: %v", err)
 			}
-
 			gotNames := namesOf(got)
-			want := append([]string(nil), tc.want...)
+			want := make([]string, 0, len(tc.want))
+			want = append(want, tc.want...)
 			sort.Strings(want)
-
-			if len(gotNames) != len(want) {
+			if !reflect.DeepEqual(gotNames, want) {
 				t.Fatalf("got %v, want %v", gotNames, want)
-			}
-			for i := range gotNames {
-				if gotNames[i] != want[i] {
-					t.Fatalf("got %v, want %v", gotNames, want)
-				}
 			}
 		})
 	}
+
+	t.Run("unexpected shape errors", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"unexpected":"shape"}`))
+		}))
+		defer srv.Close()
+
+		client := NewSpoolmanClient(srv.URL, 5, "", "")
+		if _, err := client.getLocationsFromList(); err == nil {
+			t.Fatal("expected an error for an unrecognized JSON shape, got nil")
+		}
+	})
+}
+
+func TestUpdateLocationByName(t *testing.T) {
+	t.Run("renames all spools carrying the old name", func(t *testing.T) {
+		srv := newFakeSpoolman(t)
+		srv.Spools = map[int]*fakeSpool{
+			1: {ID: 1, Location: "Closet Shelf"},
+			2: {ID: 2, Location: "Closet Shelf"},
+			3: {ID: 3, Location: "Printer A"},
+		}
+
+		client := NewSpoolmanClient(srv.URL(), 5, "", "")
+		if err := client.UpdateLocationByName("Closet Shelf", "Garage"); err != nil {
+			t.Fatalf("UpdateLocationByName error: %v", err)
+		}
+
+		if srv.Spools[1].Location != "Garage" || srv.Spools[2].Location != "Garage" {
+			t.Fatalf("expected spools 1 and 2 to move to Garage, got %q and %q",
+				srv.Spools[1].Location, srv.Spools[2].Location)
+		}
+		if srv.Spools[3].Location != "Printer A" {
+			t.Fatalf("spool 3 should be untouched, got %q", srv.Spools[3].Location)
+		}
+		if len(srv.PatchCalls) != 2 {
+			t.Fatalf("expected 2 spools patched, got %d (%v)", len(srv.PatchCalls), srv.PatchCalls)
+		}
+	})
+
+	t.Run("renaming Unassigned targets empty-string locations", func(t *testing.T) {
+		srv := newFakeSpoolman(t)
+		srv.Spools = map[int]*fakeSpool{
+			1: {ID: 1, Location: ""},
+			2: {ID: 2, Location: "Printer A"},
+		}
+
+		client := NewSpoolmanClient(srv.URL(), 5, "", "")
+		if err := client.UpdateLocationByName("Unassigned", "Shelf"); err != nil {
+			t.Fatalf("UpdateLocationByName error: %v", err)
+		}
+		if srv.Spools[1].Location != "Shelf" {
+			t.Fatalf("expected empty-location spool to move to Shelf, got %q", srv.Spools[1].Location)
+		}
+	})
+
+	t.Run("renaming TO Unassigned clears the location", func(t *testing.T) {
+		srv := newFakeSpoolman(t)
+		srv.Spools = map[int]*fakeSpool{
+			1: {ID: 1, Location: "Printer A"},
+		}
+
+		client := NewSpoolmanClient(srv.URL(), 5, "", "")
+		if err := client.UpdateLocationByName("Printer A", "Unassigned"); err != nil {
+			t.Fatalf("UpdateLocationByName error: %v", err)
+		}
+		if srv.Spools[1].Location != "" {
+			t.Fatalf("expected location cleared to empty, got %q", srv.Spools[1].Location)
+		}
+	})
+
+	t.Run("no matching spools returns error", func(t *testing.T) {
+		srv := newFakeSpoolman(t)
+		srv.Spools = map[int]*fakeSpool{
+			1: {ID: 1, Location: "Printer A"},
+		}
+
+		client := NewSpoolmanClient(srv.URL(), 5, "", "")
+		err := client.UpdateLocationByName("Nonexistent", "Whatever")
+		if err == nil {
+			t.Fatalf("expected error when no spools match, got nil")
+		}
+	})
 }

--- a/testutil_test.go
+++ b/testutil_test.go
@@ -108,9 +108,8 @@ type fakeSpoolman struct {
 	mu     sync.Mutex
 	Spools map[int]*fakeSpool
 
-	PatchCalls      []int    // spool IDs that received usage updates
-	Locations       []string // locations returned by /api/v1/location (only ones with spools)
-	LocationSetting []string // predefined locations setting; nil => endpoint 404s (fall back to /location)
+	PatchCalls []int    // spool IDs that received usage updates
+	Locations  []string // locations returned by /api/v1/location (the distinct strings spools carry)
 
 	srv *httptest.Server
 }
@@ -169,6 +168,23 @@ func (f *fakeSpoolman) handle(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		fmt.Fprint(w, `{"detail":"no such spool"}`)
 
+	case r.URL.Path == "/api/v1/spool/field/location" && r.Method == http.MethodPatch:
+		var body struct {
+			Value    string `json:"value"`
+			NewValue string `json:"new_value"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		updated := 0
+		for id, sp := range f.Spools {
+			if sp.Location == body.Value {
+				sp.Location = body.NewValue
+				f.PatchCalls = append(f.PatchCalls, id)
+				updated++
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]int{"spools_updated": updated})
+
 	case strings.HasPrefix(r.URL.Path, "/api/v1/spool/") && r.Method == http.MethodPatch:
 		id := spoolIDFromPath(r.URL.Path)
 		s, ok := f.Spools[id]
@@ -191,14 +207,6 @@ func (f *fakeSpoolman) handle(w http.ResponseWriter, r *http.Request) {
 
 	case r.URL.Path == "/api/v1/filament":
 		writeJSON(w, []interface{}{})
-
-	case r.URL.Path == "/api/v1/setting/locations":
-		if f.LocationSetting == nil {
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
-		value, _ := json.Marshal(f.LocationSetting)
-		writeJSON(w, map[string]interface{}{"value": string(value), "is_set": true, "type": "array"})
 
 	case r.URL.Path == "/api/v1/location":
 		locs := make([]map[string]interface{}, 0, len(f.Locations))

--- a/web.go
+++ b/web.go
@@ -1580,6 +1580,40 @@ func (ws *WebServer) nfcUrlsHandler(c *gin.Context) {
 		})
 	}
 
+	// Union in configured toolhead locations that hold no spool yet, so a freshly
+	// added printer's toolheads can be tagged before anything is loaded into them.
+	// Spoolman only knows a location once a spool references it, so these come
+	// from FilaBridge's own config. Typed "printer" like populated toolheads, so
+	// the UI gives them the printer icon and suppresses the rename action.
+	taggedLocations := make(map[string]bool, len(spoolmanLocations))
+	for _, location := range spoolmanLocations {
+		taggedLocations[location.Name] = true
+	}
+	for name := range toolheadLocs {
+		if strings.TrimSpace(name) == "" || taggedLocations[name] {
+			continue // empty, or already tagged via a spool — don't duplicate
+		}
+
+		nfcUrl := fmt.Sprintf("http://%s/api/nfc/assign?location=%s", c.Request.Host, neturl.QueryEscape(name))
+
+		// Generate QR code (leave it empty and keep going if generation fails)
+		qrCodeBase64 := ""
+		if qrCode, err := qrcode.Encode(nfcUrl, qrcode.Medium, 256); err != nil {
+			log.Printf("Error generating QR code for toolhead location %s: %v", name, err)
+		} else {
+			qrCodeBase64 = base64.StdEncoding.EncodeToString(qrCode)
+		}
+
+		urls = append(urls, gin.H{
+			"type":           "location",
+			"location_type":  "printer",
+			"location_name":  name,
+			"display_name":   name,
+			"url":            nfcUrl,
+			"qr_code_base64": qrCodeBase64,
+		})
+	}
+
 	// Sort URLs: filaments first, then spools, then locations alphabetically by display name
 	sort.Slice(urls, func(i, j int) bool {
 		typeI := urls[i]["type"].(string)
@@ -1683,7 +1717,10 @@ func (ws *WebServer) nfcSessionStatusHandler(c *gin.Context) {
 
 // Location Management Handlers
 
-// getLocationsHandler returns only Spoolman locations (no virtual printer toolheads)
+// getLocationsHandler returns Spoolman's locations, overlaid with this
+// instance's configured toolhead locations. Spoolman only knows a location once
+// a spool references it, so toolheads on a freshly added printer would otherwise
+// be invisible until first use.
 func (ws *WebServer) getLocationsHandler(c *gin.Context) {
 	// Get Spoolman locations
 	spoolmanLocations, err := ws.bridge.spoolman.GetLocations()
@@ -1719,6 +1756,27 @@ func (ws *WebServer) getLocationsHandler(c *gin.Context) {
 		})
 	}
 
+	// Union in configured toolhead locations that have no spool yet, so a freshly
+	// added printer's toolheads are visible for NFC/QR labeling before any spool
+	// references them. Typed "printer" (like populated toolheads) so the UI gates
+	// rename on them. These come from FilaBridge's own config, not Spoolman.
+	seen := make(map[string]bool, len(allLocations))
+	for _, l := range allLocations {
+		if name, ok := l["name"].(string); ok {
+			seen[name] = true
+		}
+	}
+	for name := range toolheadLocs {
+		if strings.TrimSpace(name) == "" || seen[name] {
+			continue // empty, or already surfaced via a spool — don't duplicate
+		}
+		allLocations = append(allLocations, gin.H{
+			"name":       name,
+			"type":       "printer",
+			"is_virtual": true,
+		})
+	}
+
 	// Get Spoolman URL for the message
 	spoolmanURL := ws.bridge.spoolman.GetBaseURL()
 
@@ -1751,10 +1809,16 @@ func (ws *WebServer) updateLocationHandler(c *gin.Context) {
 		return
 	}
 
-	// Get updated location
+	// Get updated location. FindLocationByName reports "not found" as (nil, nil),
+	// which is reachable here: a location no spool carries (e.g. a config-derived
+	// toolhead location) leaves nothing for Spoolman to list under the new name.
 	location, err := ws.bridge.spoolman.FindLocationByName(req.Name)
 	if err != nil {
 		log.Printf("Warning: Could not get updated location '%s': %v", req.Name, err)
+		c.JSON(http.StatusOK, gin.H{"message": "Location updated successfully"})
+		return
+	}
+	if location == nil {
 		c.JSON(http.StatusOK, gin.H{"message": "Location updated successfully"})
 		return
 	}

--- a/web_test.go
+++ b/web_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	neturl "net/url"
 	"regexp"
 	"strings"
 	"testing"
@@ -471,14 +472,13 @@ func TestScannedStorageLocationBecomesHome(t *testing.T) {
 	}
 }
 
-// TestLocationsListEmptyAndTypeToolheads: /api/locations reads the predefined
-// locations setting so empty locations (no spools) still appear, and this
-// instance's toolhead locations are typed "printer" so the storage dropdown
-// filters them out.
+// TestLocationsListEmptyAndTypeToolheads: /api/locations reports the locations
+// Spoolman itself lists (GET /api/v1/location), and this instance's toolhead
+// locations are typed "printer" so the storage dropdown filters them out.
 func TestLocationsListEmptyAndTypeToolheads(t *testing.T) {
 	ws, _, spoolman := newTestServer(t)
-	// "Unopened" holds no spools; "TestPrinter - Toolhead 0" is a toolhead location.
-	spoolman.LocationSetting = []string{"Drybox", "Unopened", "TestPrinter - Toolhead 0"}
+	// "TestPrinter - Toolhead 0" is a toolhead location; the others are storage.
+	spoolman.Locations = []string{"Drybox", "Unopened", "TestPrinter - Toolhead 0"}
 
 	rec, body := doJSON(t, ws, http.MethodGet, "/api/locations", "")
 	if rec.Code != http.StatusOK {
@@ -499,6 +499,160 @@ func TestLocationsListEmptyAndTypeToolheads(t *testing.T) {
 	if types["TestPrinter - Toolhead 0"] != "printer" {
 		t.Errorf("toolhead location should be typed 'printer'; got %q", types["TestPrinter - Toolhead 0"])
 	}
+}
+
+// TestLocationsIncludeSpoollessToolheads: Spoolman only knows a location once a
+// spool references it, so a freshly configured printer's toolheads would be
+// invisible to /api/locations. The handler unions them in from FilaBridge's own
+// config, typed "printer" — and must not duplicate them once a spool does land
+// there.
+func TestLocationsIncludeSpoollessToolheads(t *testing.T) {
+	ws, _, spoolman := newTestServer(t)
+
+	toolheads := ws.bridge.toolheadLocationSet()
+	if len(toolheads) != 1 {
+		t.Fatalf("test fixture expects exactly 1 toolhead location, got %d (%v)", len(toolheads), toolheads)
+	}
+	var toolheadName string
+	for name := range toolheads {
+		toolheadName = name
+	}
+
+	// Spoolman reports nothing: the toolhead must still be listed, as virtual.
+	spoolman.Locations = nil
+	locs := locationsByName(t, ws)
+	if len(locs) != 1 {
+		t.Fatalf("want exactly 1 location (the spool-less toolhead), got %d (%v)", len(locs), locs)
+	}
+	entry, ok := locs[toolheadName]
+	if !ok {
+		t.Fatalf("spool-less toolhead %q missing from /api/locations (%v)", toolheadName, locs)
+	}
+	if entry["type"] != "printer" {
+		t.Errorf("spool-less toolhead type = %v, want printer", entry["type"])
+	}
+	if entry["is_virtual"] != true {
+		t.Errorf("spool-less toolhead is_virtual = %v, want true", entry["is_virtual"])
+	}
+
+	// Now a spool references it: still exactly one entry, still typed "printer",
+	// but no longer virtual — and critically, not duplicated.
+	spoolman.Locations = []string{toolheadName}
+	locs = locationsByName(t, ws)
+	if len(locs) != 1 {
+		t.Fatalf("toolhead duplicated once a spool referenced it: got %d entries (%v)", len(locs), locs)
+	}
+	entry = locs[toolheadName]
+	if entry["type"] != "printer" {
+		t.Errorf("populated toolhead type = %v, want printer", entry["type"])
+	}
+	if entry["is_virtual"] != false {
+		t.Errorf("populated toolhead is_virtual = %v, want false", entry["is_virtual"])
+	}
+}
+
+// TestNFCUrlsIncludeSpoollessToolheads: the NFC/QR tag list must offer a tag for
+// a configured toolhead before any spool has been loaded into it, typed
+// "printer" so the UI shows the printer icon and hides the rename action — and
+// must not emit a second entry once a spool does reference that location.
+func TestNFCUrlsIncludeSpoollessToolheads(t *testing.T) {
+	ws, _, spoolman := newTestServer(t)
+
+	toolheads := ws.bridge.toolheadLocationSet()
+	if len(toolheads) != 1 {
+		t.Fatalf("test fixture expects exactly 1 toolhead location, got %d (%v)", len(toolheads), toolheads)
+	}
+	var toolheadName string
+	for name := range toolheads {
+		toolheadName = name
+	}
+
+	// No spool references the toolhead: it must still get a tag.
+	spoolman.Locations = nil
+	entries := nfcLocationsByName(t, ws)
+	entry, ok := entries[toolheadName]
+	if !ok {
+		t.Fatalf("spool-less toolhead %q missing from /api/nfc/urls (%v)", toolheadName, entries)
+	}
+	if entry["location_type"] != "printer" {
+		t.Errorf("spool-less toolhead location_type = %v, want printer", entry["location_type"])
+	}
+	if qr, _ := entry["qr_code_base64"].(string); qr == "" {
+		t.Error("spool-less toolhead got no QR code, so it cannot be labeled")
+	}
+	if u, _ := entry["url"].(string); !strings.Contains(u, neturl.QueryEscape(toolheadName)) {
+		t.Errorf("toolhead NFC url %q does not encode the location name", u)
+	}
+
+	// A spool now sits there: still exactly one entry for that name.
+	spoolman.Locations = []string{toolheadName}
+	entries = nfcLocationsByName(t, ws)
+	if got := entries[toolheadName]; got == nil {
+		t.Fatalf("toolhead %q disappeared once a spool referenced it", toolheadName)
+	} else if got["location_type"] != "printer" {
+		t.Errorf("populated toolhead location_type = %v, want printer", got["location_type"])
+	}
+	if n := nfcLocationCount(t, ws, toolheadName); n != 1 {
+		t.Fatalf("toolhead tag duplicated once a spool referenced it: %d entries", n)
+	}
+}
+
+// nfcLocationsByName fetches /api/nfc/urls and indexes the "location" entries by
+// name. Duplicate names collapse, so pair it with nfcLocationCount when the
+// point of the test is that nothing was duplicated.
+func nfcLocationsByName(t *testing.T, ws *WebServer) map[string]map[string]interface{} {
+	t.Helper()
+	out := make(map[string]map[string]interface{})
+	for _, m := range nfcLocationEntries(t, ws) {
+		out[m["location_name"].(string)] = m
+	}
+	return out
+}
+
+// nfcLocationCount reports how many "location" entries carry the given name.
+func nfcLocationCount(t *testing.T, ws *WebServer, name string) int {
+	t.Helper()
+	n := 0
+	for _, m := range nfcLocationEntries(t, ws) {
+		if m["location_name"] == name {
+			n++
+		}
+	}
+	return n
+}
+
+func nfcLocationEntries(t *testing.T, ws *WebServer) []map[string]interface{} {
+	t.Helper()
+	rec, body := doJSON(t, ws, http.MethodGet, "/api/nfc/urls", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("nfc/urls: %d", rec.Code)
+	}
+	raw, _ := body["urls"].([]interface{})
+	out := make([]map[string]interface{}, 0, len(raw))
+	for _, u := range raw {
+		m, ok := u.(map[string]interface{})
+		if !ok || m["type"] != "location" {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// locationsByName fetches /api/locations and indexes the entries by name.
+func locationsByName(t *testing.T, ws *WebServer) map[string]map[string]interface{} {
+	t.Helper()
+	rec, body := doJSON(t, ws, http.MethodGet, "/api/locations", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("locations: %d", rec.Code)
+	}
+	raw, _ := body["locations"].([]interface{})
+	out := make(map[string]map[string]interface{}, len(raw))
+	for _, l := range raw {
+		m := l.(map[string]interface{})
+		out[m["name"].(string)] = m
+	}
+	return out
 }
 
 // TestMapToolheadRejectsInvalidTargets: mappings to toolheads beyond the


### PR DESCRIPTION
Fixes #44.

## Problem

With Spoolman **v0.26.0** (the rewritten client), FilaBridge imports no locations: the NFC → Location Tags tab is empty and `GET /api/locations` returns `"locations": null`, even though spools have locations and Spoolman's `/api/v1/location` returns them.

Previously `GetLocations()` tried `getLocationsFromSetting()` and only fell back to `getLocationsFromList()` (`/api/v1/location`) when the setting request **errored**:

```go
if locs, err := c.getLocationsFromSetting(); err == nil {
    return locs, nil
}
return c.getLocationsFromList()
```

On v0.26, `GET /api/v1/setting/locations` returns **HTTP 200** with an empty, never-set value (`{"value":"[]","is_set":false}`), so `getLocationsFromSetting()` succeeds with an empty slice and the code returns it — never reaching `/api/v1/location`, which holds the real data.

## Update: this PR no longer merges the two sources

The first commit unioned the `locations` setting with `/api/v1/location`, on the theory that users upgrading from an older Spoolman could have locations in both places. Further testing against a live v0.26 instance showed that reasoning doesn't hold, so the approach changed. Leaving the history here because the earlier description argued the opposite.

Three separate things are called "locations" in Spoolman v0.26:

1. the free-text `location` string on each spool, which `/api/v1/location` reports as a distinct set;
2. the legacy `locations` setting, which the v0.26 UI no longer reads or writes;
3. the `dashboard_groups` setting, which holds empty group-card layout (what "+ New Group" writes).

Only (1) is real to Spoolman. An entry that exists **solely** in the legacy setting is invisible in Spoolman's own UI, so merging it in meant FilaBridge offering users locations that Spoolman would never agree existed — and that a spool could not actually be assigned to. Locations in v0.26 are strings on spools, not first-class entities.

So `GetLocations()` is now list-only, and `getLocationsFromSetting()` is deleted. The tradeoff: locations that live only in the abandoned setting disappear from FilaBridge. They were already phantoms.

## What else was broken

Modeling locations as records with IDs hid two further bugs, both fixed here:

**Renames silently did nothing.** The old code PATCHed `/api/v1/location/{id}`, an endpoint that no longer exists in v0.26. Since locations are just strings on spools, a rename is a bulk field update: `PATCH /api/v1/spool/field/location` with `{"value": "<old>", "new_value": "<new>"}` — the same call Spoolman's own dashboard group-rename uses. Spoolman answers `200` with `{"spools_updated": N}` even when nothing matched, so a rename that moved zero spools now reports an error instead of a false success.

**A new printer's toolheads were untaggable.** Spoolman only learns a location once a spool references it, so a freshly added printer's toolheads existed nowhere until filament was first loaded into them — exactly when you'd want to print a tag for them. Both `/api/locations` and the NFC/QR tag list now union in FilaBridge's own config-derived toolhead locations, typed `"printer"` like populated toolheads so existing UI behavior (filtered out of storage pickers, rename suppressed) applies unchanged.

The architectural line: `GetLocations()` stays pure Spoolman truth, and FilaBridge's own knowledge is overlaid in the web layer.

## Other behavior changes

- **Empty locations render as "Unassigned."** A spool with an empty `location` comes back as `""`. Rather than dropping those rows or showing a blank entry, they normalize to `"Unassigned"`, matching how Spoolman and FilaMan label them. Normalization happens in one place and dedupes by final name, so a `""` and a literal `"Unassigned"` collapse into one entry. `"Unassigned"` maps back to `""` on both fields of a rename, so spools can be renamed out of (or into) the unassigned state.
- **Fixed a nil dereference** in `updateLocationHandler`: `FindLocationByName` reports "not found" as `(nil, nil)`. This was near-unreachable before, because rename errored out first; the toolhead overlay makes it reachable for a location no spool carries.

## Testing

`go build ./...`, `go vet ./...`, and `go test ./...` are green.

Unit tests:

- `TestGetLocationsFromList` — table-driven over every response shape we accept (array of objects, `data`/`results` wrappers, plain array of names), plus `""` → `"Unassigned"`, whitespace-only names, multiple blanks collapsing to one entry, blank-vs-literal-`"Unassigned"` dedupe, and an unrecognized-shape error.
- `TestGetLocations` — list-only behavior.
- `TestUpdateLocationByName` — asserts the `field/location` PATCH body, `"Unassigned"` ↔ `""` mapping in both directions, and the zero-match error.
- `TestLocationsIncludeSpoollessToolheads` / `TestNFCUrlsIncludeSpoollessToolheads` — a configured-but-empty toolhead appears in both handlers typed `"printer"` with a QR code, and is **not** duplicated once a spool references that same location.

The test harness gained a `PATCH /api/v1/spool/field/location` case returning `{"spools_updated": N}`. The `/api/v1/setting/locations` fake and its `LocationSetting` field are removed, since nothing reads that setting anymore.

Manually verified against a live Spoolman v0.26.0: the locations list, the storage dropdown (toolheads filtered out), and the NFC/QR tag list showing a configured-but-empty toolhead with a printer icon and no rename action.

## Notes

- This changes *which* locations are returned and how renames are performed. The `type` field (storage vs printer) is still derived in `web.go` via `toolheadLocationSet()`.

## Environment used to verify

- Spoolman v0.26.0 (git `f369253`), SQLite
- FilaBridge built from this branch
- Prusa MK4S + CORE One (PrusaLink)
