### PR TITLE
NFC: optional "toolhead tag first unloads the spool" workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,15 @@ FilaBridge keeps each spool's Spoolman location in step with its toolhead assign
 
 If you have exactly one printer with one toolhead configured, the Spool Tags screen also offers a Quick-Assign variant for each spool: a single tag that assigns the spool directly to your printer in one scan, with no location tag needed. Multi-toolhead users can build the same thing manually by appending `&location=<location name>` to a spool URL.
 
+#### Unloading With the Printer's Own Tag
+
+By default a toolhead tag scanned on its own waits for a spool tag, so tags pair up in whichever order you scan them. Tick **Toolhead tag first unloads the spool** under Settings → Advanced Settings → NFC Scanning Settings to change that:
+
+- **Scan spool, then printer** loads the spool, exactly as before.
+- **Scan printer on its own** unloads whatever is currently on that toolhead.
+
+That gives each printer a single tag covering both directions, with no separate "empty" tag to keep track of. The unloaded spool follows the same Spoolman location rules as any other unassignment above, so it returns to its own home location or to your default storage location. Storage location tags are unaffected and always wait for a spool, and scanning a toolhead that has nothing loaded reports that rather than reporting an unload.
+
 ## Notifications
 
 FilaBridge can POST to a webhook of your choice for the two events it uniquely knows about. Your printer's own app already handles print-started/finished alerts, so FilaBridge doesn't duplicate them... it only notifies about things that depend on Spoolman data or on its own view of the printer. Set a **Notification webhook URL** in Settings → Basic Configuration to enable it or leave it empty to disable.
@@ -285,6 +294,8 @@ The web interface also provides REST API endpoints:
 - `GET /api/nfc/assign` - Handle NFC tag scans (spool, location, or both in one URL)
 - `GET /api/nfc/urls` - Get all NFC URLs with QR codes
 - `GET /api/nfc/session/status` - Check NFC session status
+- `GET /api/config/nfc-toolhead-unload` - Get the "toolhead tag first unloads" setting
+- `PUT /api/config/nfc-toolhead-unload` - Set the "toolhead tag first unloads" setting
 - `GET/POST /api/locations`, `PUT/DELETE /api/locations/{name}` - Manage locations
 - `WS /ws/status` - WebSocket endpoint for real-time status updates
 

--- a/bridge.go
+++ b/bridge.go
@@ -344,6 +344,7 @@ func (b *FilamentBridge) initializeDefaultConfig() error {
 		ConfigKeyRunoutWarningEnabled:            {"true", "Show a dashboard warning when the mapped spool has less filament remaining than the print requires"},
 		ConfigKeyRunoutPauseEnabled:              {"false", "Also pause the print when a low-filament warning fires (acknowledging resumes it)"},
 		ConfigKeyNotifyWebhookURL:                {"", "Webhook URL to POST a JSON notification to on a low-filament warning or an unexpected loss of connection during a print (leave empty to disable)"},
+		ConfigKeyNFCToolheadFirstUnloads:         {"false", "Scanning a toolhead tag with no spool scan pending unloads whatever is on that toolhead, so one printer tag both loads and unloads"},
 	}
 
 	// Check if this is a fresh installation by checking if any config exists
@@ -473,6 +474,30 @@ func (b *FilamentBridge) SetAutoAssignPreviousSpoolRemember(enabled bool) error 
 		value = "true"
 	}
 	return b.SetConfigValue(ConfigKeyAutoAssignPreviousSpoolRemember, value)
+}
+
+// GetNFCToolheadFirstUnloads reports whether a toolhead tag scanned with no
+// spool scan pending unloads that toolhead instead of waiting for a spool.
+// Defaults to false, including for databases predating the setting, so the
+// scan-in-any-order workflow is what an existing install keeps.
+func (b *FilamentBridge) GetNFCToolheadFirstUnloads() (bool, error) {
+	value, err := b.GetConfigValue(ConfigKeyNFCToolheadFirstUnloads)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+	return value == "true", nil
+}
+
+// SetNFCToolheadFirstUnloads sets whether a lone toolhead tag scan unloads.
+func (b *FilamentBridge) SetNFCToolheadFirstUnloads(enabled bool) error {
+	value := "false"
+	if enabled {
+		value = "true"
+	}
+	return b.SetConfigValue(ConfigKeyNFCToolheadFirstUnloads, value)
 }
 
 // GetPrintHistoryEnabled reports whether local print history is kept and the

--- a/constants.go
+++ b/constants.go
@@ -46,6 +46,7 @@ const (
 	ConfigKeyRunoutWarningEnabled            = "runout_warning_enabled"
 	ConfigKeyRunoutPauseEnabled              = "runout_pause_enabled"
 	ConfigKeyNotifyWebhookURL                = "notify_webhook_url"
+	ConfigKeyNFCToolheadFirstUnloads         = "nfc_toolhead_first_unloads"
 )
 
 // HTTP timeouts

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -143,6 +143,67 @@
     gap: 15px;
 }
 
+/* Inline "?" badge that reveals a longer explanation of a setting on hover or
+   focus. Focus (not just hover) carries it, so it is reachable by keyboard and
+   by tapping on touch screens, where hover never fires. */
+.setting-tip {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    margin-left: 6px;
+    border-radius: 50%;
+    background: rgba(255,255,255,0.15);
+    color: #fff;
+    font-size: 12px;
+    font-weight: bold;
+    font-style: normal;
+    cursor: help;
+    flex-shrink: 0;
+}
+
+.setting-tip:hover,
+.setting-tip:focus {
+    background: rgba(255,255,255,0.3);
+    outline: none;
+}
+
+.setting-tip .setting-tip-text {
+    visibility: hidden;
+    opacity: 0;
+    position: absolute;
+    bottom: calc(100% + 8px);
+    left: 50%;
+    transform: translateX(-50%);
+    width: max-content;
+    max-width: min(380px, 85vw);
+    padding: 10px 12px;
+    border-radius: 6px;
+    background: #2c3e50;
+    border: 1px solid rgba(255,255,255,0.15);
+    box-shadow: 0 6px 18px rgba(0,0,0,0.35);
+    color: #f1f1f1;
+    font-size: 13px;
+    font-weight: normal;
+    line-height: 1.5;
+    text-align: left;
+    white-space: normal;
+    z-index: 10;
+    transition: opacity 0.15s;
+}
+
+.setting-tip:hover .setting-tip-text,
+.setting-tip:focus .setting-tip-text {
+    visibility: visible;
+    opacity: 1;
+}
+
+.setting-tip .setting-tip-text strong {
+    color: #fff;
+}
+
 /* Alert banners - Spoolman connection trouble, low-filament warnings, print
    errors. The same markup is produced server-side (status.html) and rebuilt live
    over the websocket, so both paths must use these classes rather than their own

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -120,6 +120,7 @@ function loadSettingsTabData(tabId) {
     } else if (tabId === 'advanced') {
         loadAdvancedSettings();
         loadAutoAssignSettings();
+        loadNFCScanningSettings();
         loadPrintHistorySettings();
     }
 }
@@ -548,6 +549,33 @@ function saveAutoAssignSettings() {
 
 // Print History settings
 let printHistoryWasEnabled = true;
+
+// NFC Scanning Settings Functions
+function loadNFCScanningSettings() {
+    fetch('/api/config/nfc-toolhead-unload')
+        .then(response => response.json())
+        .then(data => {
+            const checkbox = document.getElementById('nfcToolheadFirstUnloads');
+            if (checkbox) {
+                checkbox.checked = data.enabled === true;
+            }
+        })
+        .catch(error => {
+            console.error('Error loading NFC scanning settings:', error);
+        });
+}
+
+function saveNFCScanningSettings() {
+    const enabled = document.getElementById('nfcToolheadFirstUnloads').checked;
+
+    apiRequest('/api/config/nfc-toolhead-unload', { method: 'PUT', body: { enabled: enabled } })
+    .then(() => {
+        alert('NFC settings saved successfully!');
+    })
+    .catch(error => {
+        alert('Error saving NFC settings: ' + error.message);
+    });
+}
 
 function loadPrintHistorySettings() {
     fetch('/api/config/print-history')

--- a/templates/nfc_success.html
+++ b/templates/nfc_success.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>NFC Assignment Complete - FilaBridge</title>
+    <title>{{if .Unloaded}}NFC Unload Complete{{else}}NFC Assignment Complete{{end}} - FilaBridge</title>
     <style>
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
@@ -90,6 +90,33 @@
 </head>
 <body>
     <div class="container">
+        {{if .Unloaded}}
+        <div class="success-icon">{{if .WasEmpty}}📭{{else}}🧹{{end}}</div>
+        <h1>{{if .WasEmpty}}Toolhead Was Empty{{else}}Toolhead Unloaded!{{end}}</h1>
+        <div class="success-message">
+            {{if .WasEmpty}}
+                Nothing was loaded on this toolhead, so nothing changed.
+            {{else}}
+                The spool has been unloaded and returned to storage.
+            {{end}}
+        </div>
+        <div class="assignment-details">
+            {{if not .WasEmpty}}
+            <div class="detail-row">
+                <span class="detail-label">Spool ID:</span>
+                <span class="detail-value">{{.SpoolID}}</span>
+            </div>
+            {{end}}
+            <div class="detail-row">
+                <span class="detail-label">Printer:</span>
+                <span class="detail-value">{{.PrinterName}}</span>
+            </div>
+            <div class="detail-row">
+                <span class="detail-label">Toolhead:</span>
+                <span class="detail-value">{{.ToolheadID}}</span>
+            </div>
+        </div>
+        {{else}}
         <div class="success-icon">✅</div>
         <h1>Assignment Complete!</h1>
         <div class="success-message">
@@ -120,6 +147,7 @@
             </div>
             {{end}}
         </div>
+        {{end}}
         <a href="/" class="back-button">Back to Dashboard</a>
     </div>
 </body>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -121,6 +121,34 @@
             </div>
         </div>
 
+        <!-- NFC Scanning Settings Section -->
+        <div class="config-section" style="margin-top: 30px;">
+            <h3>📱 NFC Scanning Settings</h3>
+            <div class="help-text">
+                FilaBridge normally pairs any two tags in either order: scan a spool then a location, or a location then a spool. This changes what a toolhead tag does when it is scanned on its own.
+            </div>
+            <div class="form-group">
+                <!-- The tip sits outside the label so tapping it explains the
+                     setting instead of toggling the checkbox. -->
+                <div style="display: flex; align-items: center;">
+                    <label style="display: flex; align-items: center; gap: 10px; cursor: pointer;">
+                        <input type="checkbox" id="nfcToolheadFirstUnloads" style="width: auto; cursor: pointer;">
+                        <span>Toolhead tag first unloads the spool</span>
+                    </label>
+                    <span class="setting-tip" tabindex="0" role="note" aria-label="More about toolhead tag first unloads">?
+                        <span class="setting-tip-text">
+                            <strong>Off (default):</strong> scanning a toolhead tag first waits for a spool tag, and the two are paired in whichever order you scan them.<br><br>
+                            <strong>On:</strong> scanning a spool then a toolhead still loads that spool, but scanning a toolhead tag <em>on its own</em> unloads whatever is currently on it. One tag per printer then covers both loading and unloading, with no separate "empty" tag to keep track of.<br><br>
+                            The unloaded spool goes back to the location it came from, or to your default storage location, following the Spool Assignment Settings above. Storage location tags are unaffected either way, and always wait for a spool.
+                        </span>
+                    </span>
+                </div>
+            </div>
+            <div style="margin-top: 20px; text-align: center;">
+                <button class="btn" onclick="saveNFCScanningSettings()">💾 Save NFC Settings</button>
+            </div>
+        </div>
+
         <!-- Print History Settings Section -->
         <div class="config-section" style="margin-top: 30px;">
             <h3>🗒️ Print History Settings</h3>

--- a/web.go
+++ b/web.go
@@ -163,6 +163,8 @@ func (ws *WebServer) setupRoutes() {
 		api.PUT("/config/auto-assign-previous-spool", ws.updateAutoAssignPreviousSpoolHandler)
 		api.GET("/config/print-history", ws.getPrintHistorySettingHandler)
 		api.PUT("/config/print-history", ws.updatePrintHistorySettingHandler)
+		api.GET("/config/nfc-toolhead-unload", ws.getNFCToolheadUnloadHandler)
+		api.PUT("/config/nfc-toolhead-unload", ws.updateNFCToolheadUnloadHandler)
 		api.GET("/printers", ws.getPrintersHandler)
 		api.POST("/printers", ws.addPrinterHandler)
 		api.PUT("/printers/:id", ws.updatePrinterHandler)
@@ -799,6 +801,38 @@ func (ws *WebServer) updateAutoAssignPreviousSpoolHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "Auto-assign previous spool settings updated successfully"})
 }
 
+// getNFCToolheadUnloadHandler returns whether a lone toolhead tag scan unloads
+func (ws *WebServer) getNFCToolheadUnloadHandler(c *gin.Context) {
+	enabled, err := ws.bridge.GetNFCToolheadFirstUnloads()
+	if err != nil {
+		internalError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"enabled": enabled})
+}
+
+// updateNFCToolheadUnloadHandler sets whether a lone toolhead tag scan unloads
+func (ws *WebServer) updateNFCToolheadUnloadHandler(c *gin.Context) {
+	// Note: no binding:"required" on Enabled - the validator treats false as a
+	// missing value, which would make it impossible to ever disable the feature.
+	var req struct {
+		Enabled bool `json:"enabled"`
+	}
+
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid JSON"})
+		return
+	}
+
+	if err := ws.bridge.SetNFCToolheadFirstUnloads(req.Enabled); err != nil {
+		internalError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "NFC toolhead unload setting updated successfully"})
+}
+
 // getPrintersHandler returns all configured printers
 func (ws *WebServer) getPrintersHandler(c *gin.Context) {
 	printerConfigs, err := ws.bridge.GetAllPrinterConfigs()
@@ -1341,6 +1375,16 @@ func (ws *WebServer) nfcAssignHandler(c *gin.Context) {
 		}
 	}
 
+	// Optional workflow: with "toolhead tag first unloads" on, a toolhead tag
+	// scanned on its own means "take off whatever is loaded" rather than "wait
+	// for a spool", so one printer tag covers both directions. Scans carrying a
+	// spool, and scans landing on a session that already has a spool waiting,
+	// still assign exactly as they do with the mode off. Storage locations
+	// (drybox, shelf) are deliberately left out: clearing one has no meaning.
+	if spoolID == 0 && isPrinterLocation && ws.handleToolheadFirstUnload(c, sessionID, printerName, toolheadID, locationName) {
+		return
+	}
+
 	// Create or update session
 	session, err := ws.bridge.createOrUpdateSession(sessionID, spoolID, printerName, toolheadID, locationName, isPrinterLocation)
 	if err != nil {
@@ -1400,6 +1444,64 @@ func (ws *WebServer) nfcAssignHandler(c *gin.Context) {
 	})
 }
 
+// handleToolheadFirstUnload unloads a toolhead when its tag is scanned with no
+// spool scan pending and the mode is on. It reports whether it rendered a
+// response; false means the scan falls through to the normal session flow.
+func (ws *WebServer) handleToolheadFirstUnload(c *gin.Context, sessionID string, printerName string, toolheadID int, locationName string) bool {
+	enabled, err := ws.bridge.GetNFCToolheadFirstUnloads()
+	if err != nil {
+		// A setting that cannot be read is treated as off: the scan-in-any-order
+		// flow is the safe fallback, since it never discards a mapping.
+		log.Printf("Warning: Failed to check NFC toolhead unload setting: %v", err)
+		return false
+	}
+	if !enabled {
+		return false
+	}
+
+	// A spool already waiting in the session means this scan is the second half
+	// of a load, which the normal flow completes.
+	if session, err := ws.bridge.getSession(sessionID); err == nil && session.HasSpool {
+		return false
+	}
+
+	spoolID, err := ws.bridge.GetToolheadMapping(printerName, toolheadID)
+	if err != nil {
+		ws.renderPage(c, http.StatusInternalServerError, "nfc_error.html", gin.H{
+			"Error": "Failed to read toolhead mapping: " + err.Error(),
+		})
+		return true
+	}
+
+	// An empty toolhead is reported rather than silently succeeding, so a scan
+	// that did nothing does not read as one that unloaded something.
+	if spoolID > 0 {
+		// UnmapToolhead sends the spool back to its remembered location or the
+		// default storage one, per the auto-assign settings.
+		if err := ws.bridge.UnmapToolhead(printerName, toolheadID); err != nil {
+			ws.renderPage(c, http.StatusInternalServerError, "nfc_error.html", gin.H{
+				"Error": "Unload failed: " + err.Error(),
+			})
+			return true
+		}
+		ws.BroadcastStatus()
+	}
+
+	// Drop any half-finished session so a location left over from an earlier
+	// scan cannot pair up with whatever gets scanned next.
+	ws.bridge.deleteSession(sessionID)
+
+	ws.renderPage(c, http.StatusOK, "nfc_success.html", gin.H{
+		"Unloaded":     true,
+		"WasEmpty":     spoolID == 0,
+		"SpoolID":      spoolID,
+		"PrinterName":  printerName,
+		"ToolheadID":   toolheadID,
+		"LocationName": locationName,
+	})
+	return true
+}
+
 // nfcUrlsHandler returns all available NFC URLs with QR codes
 func (ws *WebServer) nfcUrlsHandler(c *gin.Context) {
 	var urls []gin.H
@@ -1435,6 +1537,11 @@ func (ws *WebServer) nfcUrlsHandler(c *gin.Context) {
 		comboURL := ""
 		comboQRBase64 := ""
 		if quickAssignLocation != "" {
+			// Keep spool ahead of location in the query string. Both are read
+			// from the same request so order does not change this handler's
+			// result, but a spool-first URL also reads correctly to anyone
+			// inspecting a tag, and never looks like the lone toolhead scan that
+			// the "toolhead tag first unloads" mode treats as an unload.
 			comboURL = fmt.Sprintf("http://%s/api/nfc/assign?spool=%d&location=%s",
 				c.Request.Host, spool.ID, neturl.QueryEscape(quickAssignLocation))
 			if qrCode, err := qrcode.Encode(comboURL, qrcode.Medium, 256); err != nil {

--- a/web_test.go
+++ b/web_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	neturl "net/url"
 	"regexp"
 	"strings"
 	"testing"
@@ -669,5 +670,176 @@ func TestDashboardSpoolmanLink(t *testing.T) {
 	rec, _ = doJSON(t, ws, http.MethodGet, "/", "")
 	if strings.Contains(rec.Body.String(), "Spoolman ↗") {
 		t.Fatal("Spoolman link rendered without a configured URL")
+	}
+}
+
+// nfcScan performs an NFC tag scan against the assign endpoint and returns the
+// rendered page body. Query values are escaped for the caller so location names
+// with spaces and dashes survive the trip.
+func nfcScan(t *testing.T, ws *WebServer, spool string, location string) string {
+	t.Helper()
+	q := neturl.Values{}
+	if spool != "" {
+		q.Set("spool", spool)
+	}
+	if location != "" {
+		q.Set("location", location)
+	}
+	rec, _ := doJSON(t, ws, http.MethodGet, "/api/nfc/assign?"+q.Encode(), "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("nfc scan (spool=%q location=%q): status %d: %s", spool, location, rec.Code, rec.Body.String())
+	}
+	return rec.Body.String()
+}
+
+// setToolheadUnloadMode turns the "toolhead tag first unloads" workflow on or
+// off through the API, the same way the settings page does.
+func setToolheadUnloadMode(t *testing.T, ws *WebServer, enabled bool) {
+	t.Helper()
+	body := `{"enabled":false}`
+	if enabled {
+		body = `{"enabled":true}`
+	}
+	rec, _ := doJSON(t, ws, http.MethodPut, "/api/config/nfc-toolhead-unload", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("set toolhead unload mode: status %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// mappedSpool returns the spool currently mapped to the test printer's only
+// toolhead, or 0 when it is empty.
+func mappedSpool(t *testing.T, ws *WebServer) int {
+	t.Helper()
+	spoolID, err := ws.bridge.GetToolheadMapping("TestPrinter", 0)
+	if err != nil {
+		t.Fatalf("GetToolheadMapping: %v", err)
+	}
+	return spoolID
+}
+
+// TestNFCToolheadFirstUnload covers the optional workflow where a toolhead tag
+// scanned on its own unloads that toolhead (issue #42), including the guarantee
+// that everything else about NFC scanning is unchanged while it is off.
+func TestNFCToolheadFirstUnload(t *testing.T) {
+	const toolhead = "TestPrinter - Toolhead 0"
+
+	// Each subtest gets its own server: NFC sessions are keyed by client IP,
+	// which is identical across requests here, so a shared server would leak
+	// half-finished sessions from one case into the next.
+	setup := func(t *testing.T) (*WebServer, *fakeSpoolman) {
+		t.Helper()
+		ws, _, spoolman := newTestServer(t)
+		spoolman.Spools[7] = &fakeSpool{ID: 7, Name: "Galaxy Black", RemainingWeight: 800}
+		return ws, spoolman
+	}
+
+	t.Run("off: toolhead first still waits for a spool", func(t *testing.T) {
+		ws, _ := setup(t)
+		if err := ws.bridge.SetToolheadMapping("TestPrinter", 0, 7); err != nil {
+			t.Fatalf("SetToolheadMapping: %v", err)
+		}
+
+		body := nfcScan(t, ws, "", toolhead)
+		if !strings.Contains(body, "Now scan a spool tag") {
+			t.Fatalf("expected the scan-in-any-order progress page, got: %s", body)
+		}
+		if got := mappedSpool(t, ws); got != 7 {
+			t.Fatalf("toolhead mapping = %d, want it left alone at 7", got)
+		}
+	})
+
+	t.Run("on: toolhead first unloads the loaded spool", func(t *testing.T) {
+		ws, spoolman := setup(t)
+		setToolheadUnloadMode(t, ws, true)
+		if err := ws.bridge.SetToolheadMapping("TestPrinter", 0, 7); err != nil {
+			t.Fatalf("SetToolheadMapping: %v", err)
+		}
+
+		body := nfcScan(t, ws, "", toolhead)
+		if !strings.Contains(body, "Toolhead Unloaded") {
+			t.Fatalf("expected the unload page, got: %s", body)
+		}
+		if got := mappedSpool(t, ws); got != 0 {
+			t.Fatalf("toolhead mapping = %d, want it cleared", got)
+		}
+		// The spool left the toolhead in Spoolman too, not just in FilaBridge.
+		if got := spoolman.Spools[7].Location; got == toolhead {
+			t.Fatalf("spool 7 still sits at %q in Spoolman", got)
+		}
+	})
+
+	t.Run("on: empty toolhead says so instead of claiming an unload", func(t *testing.T) {
+		ws, _ := setup(t)
+		setToolheadUnloadMode(t, ws, true)
+
+		body := nfcScan(t, ws, "", toolhead)
+		if !strings.Contains(body, "Toolhead Was Empty") {
+			t.Fatalf("expected the empty-toolhead page, got: %s", body)
+		}
+		if strings.Contains(body, "Toolhead Unloaded") {
+			t.Fatal("empty toolhead reported as an unload")
+		}
+	})
+
+	t.Run("on: spool then toolhead still loads", func(t *testing.T) {
+		ws, _ := setup(t)
+		setToolheadUnloadMode(t, ws, true)
+
+		if body := nfcScan(t, ws, "7", ""); !strings.Contains(body, "Now scan a location tag") {
+			t.Fatalf("expected the progress page after a spool scan, got: %s", body)
+		}
+		if body := nfcScan(t, ws, "", toolhead); !strings.Contains(body, "Assignment Complete") {
+			t.Fatalf("expected the assignment page, got: %s", body)
+		}
+		if got := mappedSpool(t, ws); got != 7 {
+			t.Fatalf("toolhead mapping = %d, want spool 7 loaded", got)
+		}
+	})
+
+	t.Run("on: single-scan combo URL still loads", func(t *testing.T) {
+		ws, _ := setup(t)
+		setToolheadUnloadMode(t, ws, true)
+
+		if body := nfcScan(t, ws, "7", toolhead); !strings.Contains(body, "Assignment Complete") {
+			t.Fatalf("expected the assignment page, got: %s", body)
+		}
+		if got := mappedSpool(t, ws); got != 7 {
+			t.Fatalf("toolhead mapping = %d, want spool 7 loaded", got)
+		}
+	})
+
+	t.Run("on: storage location tags are unaffected", func(t *testing.T) {
+		ws, _ := setup(t)
+		setToolheadUnloadMode(t, ws, true)
+
+		body := nfcScan(t, ws, "", "Drybox")
+		if !strings.Contains(body, "Now scan a spool tag") {
+			t.Fatalf("expected a storage location to wait for a spool, got: %s", body)
+		}
+	})
+}
+
+// TestNFCToolheadUnloadSettingRoundTrip: the setting defaults to off, so an
+// existing install keeps the scan-in-any-order workflow until it opts in.
+func TestNFCToolheadUnloadSettingRoundTrip(t *testing.T) {
+	ws, _, _ := newTestServer(t)
+
+	_, body := doJSON(t, ws, http.MethodGet, "/api/config/nfc-toolhead-unload", "")
+	if body["enabled"] != false {
+		t.Fatalf("enabled = %v, want false by default", body["enabled"])
+	}
+
+	setToolheadUnloadMode(t, ws, true)
+	_, body = doJSON(t, ws, http.MethodGet, "/api/config/nfc-toolhead-unload", "")
+	if body["enabled"] != true {
+		t.Fatalf("enabled = %v, want true after opting in", body["enabled"])
+	}
+
+	// Turning it back off has to work: a bool with binding:"required" would
+	// reject false as a missing value and strand the user in the new workflow.
+	setToolheadUnloadMode(t, ws, false)
+	_, body = doJSON(t, ws, http.MethodGet, "/api/config/nfc-toolhead-unload", "")
+	if body["enabled"] != false {
+		t.Fatalf("enabled = %v, want false after opting back out", body["enabled"])
 	}
 }


### PR DESCRIPTION
Off by default, so tags still pair in either order for everyone who wants that. When enabled, a toolhead tag scanned on its own unloads whatever is on it, so one tag per printer covers both directions and no dedicated "empty" tags are needed. Spool then toolhead still loads as before and storage location tags are unaffected. Unloaded spools follow the existing Spool Assignment rules, returning to their remembered home or the default storage location.

Lives under Settings, Advanced Settings, NFC Scanning Settings

Closes #42