### PR TITLE
fix(spoolman): import locations via /api/v1/location on v0.26 (#44)

### DIFF
--- a/spoolman.go
+++ b/spoolman.go
@@ -388,56 +388,21 @@ type SpoolmanLocation struct {
 	Archived bool   `json:"archived"`
 }
 
-// GetLocations returns Spoolman's predefined locations. It prefers the
-// `locations` setting, which lists ALL created locations (including empty ones);
-// older Spoolman versions without that setting fall back to the /location list,
-// which only reports locations that currently hold a spool.
+// GetLocations returns Spoolman's locations as reported by /api/v1/location.
+//
+// It used to prefer the `locations` setting, falling back to /api/v1/location
+// only when that request errored. On Spoolman v0.26 the setting request
+// succeeds with an empty, never-set value ({"value":"[]","is_set":false},
+// HTTP 200), so the fallback never ran and no locations were imported. The
+// v0.26 client has no Locations page and never writes that setting — locations
+// there are just the free-text `location` strings on spools — so the setting is
+// not a source of truth to fall back to.
 func (c *SpoolmanClient) GetLocations() ([]SpoolmanLocation, error) {
-	if locs, err := c.getLocationsFromSetting(); err == nil {
-		return locs, nil
-	}
 	return c.getLocationsFromList()
 }
 
-// getLocationsFromSetting reads the predefined location list from Spoolman's
-// `locations` setting, whose value is a JSON-encoded array of names.
-func (c *SpoolmanClient) getLocationsFromSetting() ([]SpoolmanLocation, error) {
-	req, err := http.NewRequest("GET", c.baseURL+"/api/v1/setting/locations", nil)
-	if err != nil {
-		return nil, err
-	}
-	c.addAuthHeader(req)
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("spoolman setting/locations returned HTTP %d", resp.StatusCode)
-	}
-	var setting struct {
-		Value string `json:"value"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&setting); err != nil {
-		return nil, err
-	}
-	var names []string
-	if strings.TrimSpace(setting.Value) != "" {
-		if err := json.Unmarshal([]byte(setting.Value), &names); err != nil {
-			return nil, fmt.Errorf("parsing locations setting value: %w", err)
-		}
-	}
-	locations := make([]SpoolmanLocation, 0, len(names))
-	for _, n := range names {
-		if strings.TrimSpace(n) != "" {
-			locations = append(locations, SpoolmanLocation{Name: n})
-		}
-	}
-	return locations, nil
-}
-
-// getLocationsFromList reads locations from /api/v1/location — only those that
-// currently hold a spool. Fallback for Spoolman without the locations setting.
+// getLocationsFromList reads locations from /api/v1/location, i.e. the distinct
+// location strings currently referenced by spools.
 func (c *SpoolmanClient) getLocationsFromList() ([]SpoolmanLocation, error) {
 	req, err := http.NewRequest("GET", c.baseURL+"/api/v1/location", nil)
 	if err != nil {
@@ -464,7 +429,7 @@ func (c *SpoolmanClient) getLocationsFromList() ([]SpoolmanLocation, error) {
 	// 1) Try standard array of objects
 	var locations []SpoolmanLocation
 	if err := json.Unmarshal(bodyBytes, &locations); err == nil {
-		return locations, nil
+		return withNonEmptyNames(locations), nil
 	}
 
 	// 2) Try { data: [...] } wrapper
@@ -474,20 +439,24 @@ func (c *SpoolmanClient) getLocationsFromList() ([]SpoolmanLocation, error) {
 	}
 	if err := json.Unmarshal(bodyBytes, &dataWrapper); err == nil {
 		if len(dataWrapper.Data) > 0 {
-			return dataWrapper.Data, nil
+			return withNonEmptyNames(dataWrapper.Data), nil
 		}
 		if len(dataWrapper.Results) > 0 {
-			return dataWrapper.Results, nil
+			return withNonEmptyNames(dataWrapper.Results), nil
 		}
 	}
 
-	// 3) Try simple array of names like ["Testing", ...]
+	// 3) Try simple array of names like ["Testing", ...] (Spoolman v0.26).
+	// Build a fresh slice rather than appending to `locations`: the failed
+	// attempt at shape 1 leaves it grown to the element count with zero-value
+	// entries, and appending here would carry those blanks through.
 	var names []string
 	if err := json.Unmarshal(bodyBytes, &names); err == nil {
+		named := make([]SpoolmanLocation, 0, len(names))
 		for _, n := range names {
-			locations = append(locations, SpoolmanLocation{Name: n})
+			named = append(named, SpoolmanLocation{Name: n})
 		}
-		return locations, nil
+		return withNonEmptyNames(named), nil
 	}
 
 	// Log snippet for diagnostics and return error
@@ -497,6 +466,20 @@ func (c *SpoolmanClient) getLocationsFromList() ([]SpoolmanLocation, error) {
 	}
 	log.Printf("Spoolman /location unexpected JSON. Snippet: %s", snippet)
 	return nil, fmt.Errorf("error decoding locations from Spoolman: unexpected JSON shape")
+}
+
+// withNonEmptyNames drops locations whose name is empty or whitespace-only.
+// Now that /api/v1/location is the only source, unassigned spools surface as a
+// "" location, which is not a place anything can be filed under.
+func withNonEmptyNames(locs []SpoolmanLocation) []SpoolmanLocation {
+	out := make([]SpoolmanLocation, 0, len(locs))
+	for _, loc := range locs {
+		if strings.TrimSpace(loc.Name) == "" {
+			continue
+		}
+		out = append(out, loc)
+	}
+	return out
 }
 
 // GetOrCreateLocation gets an existing location by name

--- a/spoolman_test.go
+++ b/spoolman_test.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// namesOf extracts the Name field from each location, sorted, for
+// order-independent comparison.
+func namesOf(locs []SpoolmanLocation) []string {
+	out := make([]string, 0, len(locs))
+	for _, l := range locs {
+		out = append(out, l.Name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestGetLocations pins the fix for #44: locations come from /api/v1/location.
+// The `locations` setting is not consulted, so a Spoolman v0.26 instance — which
+// answers that setting with an empty, never-set value and HTTP 200 — still
+// reports the locations its spools actually carry.
+func TestGetLocations(t *testing.T) {
+	t.Run("reads the location list", func(t *testing.T) {
+		srv := newFakeSpoolman(t)
+		srv.Locations = []string{"Closet Shelf", "Printer A"}
+
+		client := NewSpoolmanClient(srv.URL(), 5, "", "")
+		got, err := client.GetLocations()
+		if err != nil {
+			t.Fatalf("GetLocations returned error: %v", err)
+		}
+
+		want := []string{"Closet Shelf", "Printer A"}
+		if gotNames := namesOf(got); !reflect.DeepEqual(gotNames, want) {
+			t.Fatalf("got %v, want %v", gotNames, want)
+		}
+	})
+
+	// The regression itself: before the fix, an empty-but-successful
+	// setting response short-circuited GetLocations and returned nothing.
+	t.Run("ignores an empty locations setting", func(t *testing.T) {
+		var settingHits int
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch r.URL.Path {
+			case "/api/v1/setting/locations":
+				settingHits++
+				_, _ = w.Write([]byte(`{"value":"[]","is_set":false}`))
+			case "/api/v1/location":
+				_, _ = w.Write([]byte(`["Closet Shelf","Printer A"]`))
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer srv.Close()
+
+		client := NewSpoolmanClient(srv.URL, 5, "", "")
+		got, err := client.GetLocations()
+		if err != nil {
+			t.Fatalf("GetLocations returned error: %v", err)
+		}
+
+		want := []string{"Closet Shelf", "Printer A"}
+		if gotNames := namesOf(got); !reflect.DeepEqual(gotNames, want) {
+			t.Fatalf("got %v, want %v — an empty setting must not suppress the list", gotNames, want)
+		}
+		if settingHits != 0 {
+			t.Errorf("locations setting was requested %d times; it should not be consulted", settingHits)
+		}
+	})
+}
+
+// TestGetLocationsFromList pins the response shapes we accept from
+// GET /api/v1/location, and that blank names are skipped rather than surfaced
+// as nameless entries.
+func TestGetLocationsFromList(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want []string
+	}{
+		{
+			name: "array of objects",
+			body: `[{"id":1,"name":"Closet Shelf"},{"id":2,"name":"Printer A"}]`,
+			want: []string{"Closet Shelf", "Printer A"},
+		},
+		{
+			name: "data wrapper",
+			body: `{"data":[{"id":1,"name":"Closet Shelf"}]}`,
+			want: []string{"Closet Shelf"},
+		},
+		{
+			name: "results wrapper",
+			body: `{"results":[{"id":1,"name":"Printer A"}]}`,
+			want: []string{"Printer A"},
+		},
+		{
+			name: "plain array of names",
+			body: `["Closet Shelf","Printer A"]`,
+			want: []string{"Closet Shelf", "Printer A"},
+		},
+		{
+			name: "blank name skipped",
+			body: `[{"id":1,"name":""},{"id":2,"name":"Printer A"}]`,
+			want: []string{"Printer A"},
+		},
+		{
+			name: "whitespace-only name skipped",
+			body: `["   ","Printer A"]`,
+			want: []string{"Printer A"},
+		},
+		{
+			name: "empty list",
+			body: `[]`,
+			want: []string{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			client := NewSpoolmanClient(srv.URL, 5, "", "")
+			got, err := client.getLocationsFromList()
+			if err != nil {
+				t.Fatalf("getLocationsFromList error: %v", err)
+			}
+			gotNames := namesOf(got)
+			want := make([]string, 0, len(tc.want))
+			want = append(want, tc.want...)
+			sort.Strings(want)
+			if !reflect.DeepEqual(gotNames, want) {
+				t.Fatalf("got %v, want %v", gotNames, want)
+			}
+		})
+	}
+
+	t.Run("unexpected shape errors", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"unexpected":"shape"}`))
+		}))
+		defer srv.Close()
+
+		client := NewSpoolmanClient(srv.URL, 5, "", "")
+		if _, err := client.getLocationsFromList(); err == nil {
+			t.Fatal("expected an error for an unrecognized JSON shape, got nil")
+		}
+	})
+}

--- a/static/js/nfc.js
+++ b/static/js/nfc.js
@@ -168,10 +168,11 @@ async function loadLocationTags(dataPromise) {
         const spoolmanURL = data.spoolman_url || '';
         const messageBanner = document.createElement('div');
         messageBanner.className = 'nfc-info-banner alert alert-warning';
-        
+
         let bannerHTML = '<strong>ℹ️ Location Management:</strong><br>';
-        bannerHTML += 'It is not possible via the Spoolman API to add locations automatically. ';
-        bannerHTML += 'To create locations, please do so via Spoolman. Then they will show up here.';
+        bannerHTML += 'Locations appear here when a spool is assigned. ';
+        bannerHTML += 'Use Spoolman to update spool locations. ';
+        bannerHTML += 'For printer toolheads, use the Filament Status tab to assign a spool.';
         
         if (spoolmanURL) {
             // Append /locations to the Spoolman URL
@@ -209,9 +210,12 @@ async function loadLocationTags(dataPromise) {
                 <div class="item-info">
                     <div class="item-name">${url.display_name}</div>
                 </div>
+                <!-- Rename disabled until it operates on spools instead of the
+                     abandoned locations setting; restored in a follow-up PR.
                 <div class="location-actions">
                     ${renderLocationActions(url)}
                 </div>
+                -->
             `;
             
             // Add click handler

--- a/testutil_test.go
+++ b/testutil_test.go
@@ -108,9 +108,8 @@ type fakeSpoolman struct {
 	mu     sync.Mutex
 	Spools map[int]*fakeSpool
 
-	PatchCalls      []int    // spool IDs that received usage updates
-	Locations       []string // locations returned by /api/v1/location (only ones with spools)
-	LocationSetting []string // predefined locations setting; nil => endpoint 404s (fall back to /location)
+	PatchCalls []int    // spool IDs that received usage updates
+	Locations  []string // locations returned by /api/v1/location (the distinct strings spools carry)
 
 	srv *httptest.Server
 }
@@ -191,14 +190,6 @@ func (f *fakeSpoolman) handle(w http.ResponseWriter, r *http.Request) {
 
 	case r.URL.Path == "/api/v1/filament":
 		writeJSON(w, []interface{}{})
-
-	case r.URL.Path == "/api/v1/setting/locations":
-		if f.LocationSetting == nil {
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
-		value, _ := json.Marshal(f.LocationSetting)
-		writeJSON(w, map[string]interface{}{"value": string(value), "is_set": true, "type": "array"})
 
 	case r.URL.Path == "/api/v1/location":
 		locs := make([]map[string]interface{}, 0, len(f.Locations))

--- a/web.go
+++ b/web.go
@@ -1917,6 +1917,12 @@ func (ws *WebServer) updateLocationHandler(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"message": "Location updated successfully"})
 		return
 	}
+	// FindLocationByName reports "not found" as (nil, nil), so a missing
+	// location arrives here as a nil pointer rather than an error.
+	if location == nil {
+		c.JSON(http.StatusOK, gin.H{"message": "Location updated successfully"})
+		return
+	}
 
 	c.JSON(http.StatusOK, gin.H{
 		"message": "Location updated successfully",

--- a/web_test.go
+++ b/web_test.go
@@ -492,14 +492,16 @@ func TestScannedStorageLocationBecomesHome(t *testing.T) {
 	}
 }
 
-// TestLocationsListEmptyAndTypeToolheads: /api/locations reads the predefined
-// locations setting so empty locations (no spools) still appear, and this
-// instance's toolhead locations are typed "printer" so the storage dropdown
-// filters them out.
-func TestLocationsListEmptyAndTypeToolheads(t *testing.T) {
+// TestLocationsListAndTypeToolheads: /api/locations lists what Spoolman reports
+// from /api/v1/location, skipping the blank names that unassigned spools
+// produce, and types this instance's toolhead locations "printer" so the
+// storage dropdown filters them out.
+func TestLocationsListAndTypeToolheads(t *testing.T) {
 	ws, _, spoolman := newTestServer(t)
-	// "Unopened" holds no spools; "TestPrinter - Toolhead 0" is a toolhead location.
-	spoolman.LocationSetting = []string{"Drybox", "Unopened", "TestPrinter - Toolhead 0"}
+	// "TestPrinter - Toolhead 0" is a toolhead location, "Drybox" is storage.
+	// Spoolman reports an unassigned spool's location as "", and whitespace-only
+	// names occur in the wild; neither is a place anything can be filed under.
+	spoolman.Locations = []string{"Drybox", "", "   ", "TestPrinter - Toolhead 0"}
 
 	rec, body := doJSON(t, ws, http.MethodGet, "/api/locations", "")
 	if rec.Code != http.StatusOK {
@@ -511,14 +513,15 @@ func TestLocationsListEmptyAndTypeToolheads(t *testing.T) {
 		m := l.(map[string]interface{})
 		types[m["name"].(string)] = m["type"].(string)
 	}
-	if types["Unopened"] != "storage" {
-		t.Errorf("empty location 'Unopened' should be listed as storage; got %q (types: %v)", types["Unopened"], types)
-	}
 	if types["Drybox"] != "storage" {
 		t.Errorf("Drybox type = %q, want storage", types["Drybox"])
 	}
 	if types["TestPrinter - Toolhead 0"] != "printer" {
 		t.Errorf("toolhead location should be typed 'printer'; got %q", types["TestPrinter - Toolhead 0"])
+	}
+	// Catches both "" and "   ": either would land as an extra, unnamed entry.
+	if len(types) != 2 {
+		t.Errorf("blank locations must not be listed; want 2 entries, got %d (%v)", len(types), types)
 	}
 }
 


### PR DESCRIPTION
Fixes #44.

Supersedes #45, which bundled several concerns into one branch. This PR is the minimal fix for the import bug; the rest follows separately (see **Scope** below).

## Problem

On Spoolman **v0.26.0**, FilaBridge imports no locations: the NFC → Location Tags tab is empty and `GET /api/locations` returns `"locations": null`, even though spools have locations and Spoolman's `/api/v1/location` returns them.

`GetLocations()` preferred the `locations` setting and only fell back to `/api/v1/location` when that request **errored**:

```go
if locs, err := c.getLocationsFromSetting(); err == nil {
    return locs, nil
}
return c.getLocationsFromList()
```

On v0.26, `GET /api/v1/setting/locations` returns **HTTP 200** with an empty, never-set value:

```json
{"value":"[]","is_set":false}
```

So `getLocationsFromSetting()` *succeeds* with an empty slice, `GetLocations()` returns it, and the fallback never runs — the branch holding the real data is unreachable.

## Fix

`GetLocations()` reads `/api/v1/location` directly, and `getLocationsFromSetting()` is removed.

The setting isn't a source of truth worth falling back to: the v0.26 client has no Locations page and never writes it. A spool's `location` is a free-text string (it has been a plain string since the initial schema, never a FK), and `/api/v1/location` returns the distinct set of those strings — which is exactly what Spoolman's own UI displays.

Since the list is now the only source, unassigned spools surface as a `""` location. Those are skipped rather than listed as nameless entries, matching the existing behavior in the handlers.

### A latent bug in the same function

`getLocationsFromList` tries three response shapes in order. The third (plain array of names — what v0.26 actually returns) appended to the same slice the first attempt had used:

```go
var locations []SpoolmanLocation
if err := json.Unmarshal(bodyBytes, &locations); err == nil { ... }   // fails, but grows the slice
...
for _, n := range names {
    locations = append(locations, SpoolmanLocation{Name: n})          // appends onto the debris
}
```

A failed `json.Unmarshal` into `[]SpoolmanLocation` still grows the slice to the element count with zero-value entries before returning its type error. So `["Shelf","Printer A"]` decoded to **four** locations: two real, two blank. Shape 3 now builds a fresh slice.

This was invisible before because those blanks were dropped downstream; it surfaced when I mutation-tested the new blank filter.

## Also: disables the Rename action in Location Tags

The Rename link PUT to `/api/locations/{name}`, which resolved a location ID and PATCHed `/api/v1/location/{id}` — renaming the settings record that v0.26 no longer reads, and never touching the spools that actually define a location. It appeared to succeed and changed nothing.

With list-only there is no settings record to resolve at all, so the action cannot work as written, and leaving a button that fails every time is worse than not shipping one.

The markup is commented out rather than deleted, and its helpers (`renderLocationActions`, `renameLocation`) are left in place, so restoring it is a three-line change:

```diff
+                <!-- Rename disabled until it operates on spools instead of the
+                     abandoned locations setting; restored in a follow-up PR.
                 <div class="location-actions">
                     ${renderLocationActions(url)}
                 </div>
+                -->
```

**A rename that operates on spools is coming in a follow-up PR** — v0.26 added `PATCH /api/v1/spool/field/location`, which rewrites the string across every spool carrying it. That needs version-compatibility handling (the endpoint is v0.26-only), which is why it isn't bundled here.

## Banner copy

The Location Tags banner said:

> It is not possible via the Spoolman API to add locations automatically. To create locations, please do so via Spoolman. Then they will show up here.

That describes an entity model that doesn't exist — there's nothing to "create," because a location *is* a string on a spool. It now reads:

> Locations appear here when a spool is assigned. Use Spoolman to update spool locations. For printer toolheads, use the Filament Status tab to assign a spool.

## Hardening

`updateLocationHandler` dereferenced the result of `FindLocationByName`, which reports "not found" as `(nil, nil)`. That path is rarely reached today, so this is hardening rather than a user-facing fix — but the endpoint outlives the UI action, so the guard is worth having now.

## Scope

Deliberately **not** in this PR, to keep it reviewable and releasable:

- the rename rework (follow-up)
- surfacing a printer's toolhead locations before a spool references them (follow-up)
- location curation / stale-name cleanup / delete routes

## Testing

`go build ./...`, `go vet ./...`, `go test ./...` green; `gofmt` clean.

New `spoolman_test.go`:

- `TestGetLocations` — reads the location list, **and** a regression test that stands up a fake serving `{"value":"[]","is_set":false}` on the setting endpoint and asserts locations still come back, with the setting endpoint never requested.
- `TestGetLocationsFromList` — table-driven over the response shapes we accept (array of objects, `data`/`results` wrappers, plain array of names), blank and whitespace-only names skipped, and an unrecognized-shape error.

`TestLocationsListEmptyAndTypeToolheads` is renamed to `TestLocationsListAndTypeToolheads` and now seeds via the `/api/v1/location` fake rather than the settings fake; its premise ("empty locations still appear via the setting") no longer exists. Its third seed value — previously a spool-less `"Unopened"` that proved that premise — is now `""` and `"   "`, asserting that blank locations never reach the API response.

The `/api/v1/setting/locations` fake and its `LocationSetting` field are removed from the harness, since nothing reads that setting now.

### Behavior change worth calling out

Locations that existed **only** in the `locations` setting, with no spools in them, will disappear from FilaBridge after this PR. They were already invisible in Spoolman's own v0.26 UI, so this aligns the two — but it is a visible change for anyone upgrading who had predefined empty locations. The message to add a spool should guide them to restore the location.
