### PR TITLE
feat(spoolman): rename a location by moving the spools in it

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,14 @@ By default a toolhead tag scanned on its own waits for a spool tag, so tags pair
 
 That gives each printer a single tag covering both directions, with no separate "empty" tag to keep track of. The unloaded spool follows the same Spoolman location rules as any other unassignment above, so it returns to its own home location or to your default storage location. Storage location tags are unaffected and always wait for a spool, and scanning a toolhead that has nothing loaded reports that rather than reporting an unload.
 
+#### Renaming a Location
+
+A location in Spoolman is not a record of its own; it is the free-text `location` field on each spool. A location exists precisely as long as some spool is in it, which is why locations appear here only once a spool has been assigned to one, and why there is nothing to create or delete.
+
+Renaming therefore rewrites that field on every spool currently in the location. Renaming "Drybox" to "Drybox A" moves all of its spools at once, and renaming a location that holds no spools reports an error rather than silently doing nothing.
+
+> **Requires Spoolman v0.26.0 or newer.** Rename uses `PATCH /api/v1/spool/field/location`, which was added in v0.26.0. On older Spoolman versions the rename will fail; every other feature works as normal.
+
 ## Notifications
 
 FilaBridge can `POST` to a webhook of your choice for the events it uniquely knows about. Your printer's own app already handles print-started/finished alerts, so FilaBridge doesn't duplicate them... it only notifies about things that depend on Spoolman data or on its own view of the printer. Set a **Notification webhook URL** in Settings → Basic Configuration to enable it or leave it empty to disable.

--- a/spoolman.go
+++ b/spoolman.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -121,6 +122,18 @@ func (c *SpoolmanClient) addAuthHeader(req *http.Request) {
 	}
 }
 
+// SpoolmanAPIError is a non-2xx response from Spoolman. It carries the status
+// code so callers can tell apart failures that mean different things — most
+// usefully a 404, which on a versioned endpoint means "this Spoolman is too old"
+// rather than "the request was wrong". Callers that don't care can treat it as
+// a plain error; the message is unchanged from what it always was.
+type SpoolmanAPIError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *SpoolmanAPIError) Error() string { return e.Message }
+
 // handleAPIError handles API error responses from Spoolman
 func (c *SpoolmanClient) handleAPIError(resp *http.Response) error {
 	body, err := io.ReadAll(resp.Body)
@@ -131,11 +144,17 @@ func (c *SpoolmanClient) handleAPIError(resp *http.Response) error {
 	// Try to parse as Spoolman error format
 	var spoolmanErr SpoolmanError
 	if err := json.Unmarshal(body, &spoolmanErr); err == nil && spoolmanErr.Detail != "" {
-		return fmt.Errorf("spoolman API error (HTTP %d): %s - %s", resp.StatusCode, spoolmanErr.Title, spoolmanErr.Detail)
+		return &SpoolmanAPIError{
+			StatusCode: resp.StatusCode,
+			Message:    fmt.Sprintf("spoolman API error (HTTP %d): %s - %s", resp.StatusCode, spoolmanErr.Title, spoolmanErr.Detail),
+		}
 	}
 
 	// Fallback to generic error
-	return fmt.Errorf("spoolman API error (HTTP %d): %s", resp.StatusCode, string(body))
+	return &SpoolmanAPIError{
+		StatusCode: resp.StatusCode,
+		Message:    fmt.Sprintf("spoolman API error (HTTP %d): %s", resp.StatusCode, string(body)),
+	}
 }
 
 // normalizeSpoolmanBaseURL trims whitespace and trailing slashes from a
@@ -318,28 +337,40 @@ func (c *SpoolmanClient) GetAllFilaments() ([]SpoolmanFilament, error) {
 // the Spoolman base URL) and verifies a 200 response. opDesc names the
 // operation for error messages, e.g. "updating spool 3".
 func (c *SpoolmanClient) patchJSON(path string, data map[string]interface{}, opDesc string) error {
+	_, err := c.patchJSONResult(path, data, opDesc)
+	return err
+}
+
+// patchJSONResult is patchJSON for the endpoints whose response body carries
+// something we act on, such as the bulk field update's spools_updated count.
+func (c *SpoolmanClient) patchJSONResult(path string, data map[string]interface{}, opDesc string) ([]byte, error) {
 	jsonData, err := json.Marshal(data)
 	if err != nil {
-		return fmt.Errorf("error marshaling data for %s: %w", opDesc, err)
+		return nil, fmt.Errorf("error marshaling data for %s: %w", opDesc, err)
 	}
 
 	req, err := http.NewRequest("PATCH", c.baseURL+path, bytes.NewBuffer(jsonData))
 	if err != nil {
-		return fmt.Errorf("error creating PATCH request: %w", err)
+		return nil, fmt.Errorf("error creating PATCH request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	c.addAuthHeader(req)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("error %s in Spoolman: %w", opDesc, err)
+		return nil, fmt.Errorf("error %s in Spoolman: %w", opDesc, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return c.handleAPIError(resp)
+		return nil, c.handleAPIError(resp)
 	}
-	return nil
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response for %s: %w", opDesc, err)
+	}
+	return respBody, nil
 }
 
 // UpdateSpool updates spool information (used for filament usage tracking)
@@ -606,40 +637,74 @@ func (c *SpoolmanClient) UpdateSpoolLocation(spoolID int, locationName string) e
 	return nil
 }
 
-// UpdateLocation updates a location name in Spoolman
-func (c *SpoolmanClient) UpdateLocation(locationID int, newName string) error {
-	err := c.patchJSON(fmt.Sprintf("/api/v1/location/%d", locationID),
-		map[string]interface{}{"name": newName},
-		fmt.Sprintf("updating location %d", locationID))
+// UpdateLocationByName renames a location by rewriting the `location` string on
+// every spool that currently carries oldName.
+//
+// A location is not an entity in Spoolman — it is just a free-text field on a
+// spool — so renaming one means a bulk field update, which is what Spoolman's
+// own dashboard group-rename does. The previous implementation PATCHed
+// /api/v1/location/{id}; that endpoint is gone in v0.26, and even where it
+// existed it renamed a settings record without touching any spool, so the
+// rename appeared to succeed and changed nothing.
+//
+// TODO(spoolman-compat): PATCH /api/v1/spool/field/location is new in v0.26.0
+// and absent in v0.25.x, where this returns 404. The intended fallback is a
+// per-spool loop — GET /api/v1/spool?location=<old>, then PATCH
+// /api/v1/spool/{id} with {"location": new} for each, an endpoint that has
+// existed since at least v0.21. renameLocationBulk below is the single seam
+// where that version check and fallback belong; nothing else needs to change.
+func (c *SpoolmanClient) UpdateLocationByName(oldName, newName string) error {
+	updated, err := c.renameLocationBulk(oldName, newName)
 	if err != nil {
 		return err
 	}
-	log.Printf("Successfully updated Spoolman location %d to '%s'", locationID, newName)
+
+	// Spoolman answers 200 with a count even when the old name matched nothing.
+	// A rename that moved no spools changed nothing, so say so rather than
+	// reporting success.
+	if updated == 0 {
+		return fmt.Errorf("no spools are in location '%s'", oldName)
+	}
+
+	log.Printf("Successfully renamed Spoolman location '%s' to '%s' (%d spools)", oldName, newName, updated)
 	return nil
 }
 
-// UpdateLocationByName updates a location in Spoolman by name
-func (c *SpoolmanClient) UpdateLocationByName(oldName, newName string) error {
-	// First, find the location by name
-	locations, err := c.GetLocations()
+// renameLocationBulk performs the rename and reports how many spools moved.
+// It is the single seam for the version compatibility described on
+// UpdateLocationByName: a pre-v0.26 fallback belongs here and nowhere else.
+func (c *SpoolmanClient) renameLocationBulk(oldName, newName string) (int, error) {
+	body, err := c.patchJSONResult("/api/v1/spool/field/location",
+		map[string]interface{}{"value": oldName, "new_value": newName},
+		fmt.Sprintf("renaming location '%s' to '%s'", oldName, newName))
 	if err != nil {
-		return fmt.Errorf("failed to get locations: %w", err)
-	}
-
-	var locationID int
-	found := false
-	for _, loc := range locations {
-		if loc.Name == oldName && !loc.Archived {
-			locationID = loc.ID
-			found = true
-			break
+		// A 404 here means the endpoint itself is missing, not that anything
+		// about the request was wrong: it was added in Spoolman v0.26.0. Say so,
+		// rather than surfacing a bare HTTP error the user cannot act on.
+		var apiErr *SpoolmanAPIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
+			return 0, fmt.Errorf("renaming locations requires Spoolman v0.26.0 or newer; this server does not support it")
 		}
+		return 0, err
 	}
 
-	if !found {
-		return fmt.Errorf("location '%s' not found in Spoolman", oldName)
+	var result struct {
+		SpoolsUpdated *int `json:"spools_updated"`
 	}
 
-	// Update the location using its ID
-	return c.UpdateLocation(locationID, newName)
+	// An HTML body is a misconfigured URL answered by Spoolman's web UI with
+	// HTTP 200, not a response shape we failed to recognise. It has to be an
+	// error: the tolerant fallback below would otherwise report a rename that
+	// never reached the API as having moved a spool.
+	if looksLikeHTML(body) {
+		return 0, decodeSpoolmanJSON(body, c.baseURL+"/api/v1/spool/field/location", &result)
+	}
+
+	if err := json.Unmarshal(body, &result); err != nil || result.SpoolsUpdated == nil {
+		// The PATCH itself succeeded, so don't fail the rename over a response
+		// shape we don't recognize; report it as "moved something".
+		log.Printf("Warning: could not read spools_updated when renaming '%s': %v", oldName, err)
+		return 1, nil
+	}
+	return *result.SpoolsUpdated, nil
 }

--- a/spoolman_test.go
+++ b/spoolman_test.go
@@ -9,6 +9,129 @@ import (
 	"testing"
 )
 
+// TestUpdateLocationByName pins the rename contract: a location is a string on
+// spools, so renaming one is a bulk field update, and a rename that moved no
+// spools is a failure rather than a quiet success.
+func TestUpdateLocationByName(t *testing.T) {
+	t.Run("renames every spool carrying the old name", func(t *testing.T) {
+		srv := newFakeSpoolman(t)
+		srv.Spools = map[int]*fakeSpool{
+			1: {ID: 1, Location: "Closet Shelf"},
+			2: {ID: 2, Location: "Closet Shelf"},
+			3: {ID: 3, Location: "Printer A"},
+		}
+
+		client := NewSpoolmanClient(srv.URL(), 5, "", "")
+		if err := client.UpdateLocationByName("Closet Shelf", "Garage"); err != nil {
+			t.Fatalf("UpdateLocationByName error: %v", err)
+		}
+
+		if srv.Spools[1].Location != "Garage" || srv.Spools[2].Location != "Garage" {
+			t.Errorf("expected spools 1 and 2 in Garage, got %q and %q",
+				srv.Spools[1].Location, srv.Spools[2].Location)
+		}
+		if srv.Spools[3].Location != "Printer A" {
+			t.Errorf("spool 3 should be untouched, got %q", srv.Spools[3].Location)
+		}
+	})
+
+	t.Run("sends the bulk field update, not a per-spool patch", func(t *testing.T) {
+		srv := newFakeSpoolman(t)
+		srv.Spools = map[int]*fakeSpool{1: {ID: 1, Location: "Closet Shelf"}}
+
+		client := NewSpoolmanClient(srv.URL(), 5, "", "")
+		if err := client.UpdateLocationByName("Closet Shelf", "Garage"); err != nil {
+			t.Fatalf("UpdateLocationByName error: %v", err)
+		}
+
+		want := [][2]string{{"Closet Shelf", "Garage"}}
+		if !reflect.DeepEqual(srv.FieldRenames, want) {
+			t.Fatalf("field/location calls = %v, want %v", srv.FieldRenames, want)
+		}
+		// The old implementation resolved an ID and PATCHed a location record.
+		if len(srv.PatchCalls) != 0 {
+			t.Errorf("rename should not patch individual spools, got %v", srv.PatchCalls)
+		}
+	})
+
+	t.Run("no matching spools is an error, not a silent no-op", func(t *testing.T) {
+		srv := newFakeSpoolman(t)
+		srv.Spools = map[int]*fakeSpool{1: {ID: 1, Location: "Printer A"}}
+
+		client := NewSpoolmanClient(srv.URL(), 5, "", "")
+		err := client.UpdateLocationByName("Nonexistent", "Whatever")
+		if err == nil {
+			t.Fatal("expected an error when no spools carry the old name, got nil")
+		}
+		if srv.Spools[1].Location != "Printer A" {
+			t.Errorf("unrelated spool was modified: %q", srv.Spools[1].Location)
+		}
+	})
+
+	// On pre-v0.26 Spoolman the bulk endpoint does not exist. A bare
+	// "HTTP 404" tells the user nothing they can act on; the message has to
+	// name the cause and the fix.
+	t.Run("old Spoolman reports a version problem, not a raw 404", func(t *testing.T) {
+		srv := newFakeSpoolman(t)
+		srv.NoFieldEndpoint = true
+		srv.Spools = map[int]*fakeSpool{1: {ID: 1, Location: "Closet Shelf"}}
+
+		client := NewSpoolmanClient(srv.URL(), 5, "", "")
+		err := client.UpdateLocationByName("Closet Shelf", "Garage")
+		if err == nil {
+			t.Fatal("expected an error when the endpoint is missing, got nil")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "v0.26.0") {
+			t.Errorf("error should name the required version, got %q", msg)
+		}
+		if strings.Contains(msg, "404") {
+			t.Errorf("error should explain the cause, not leak the status code: %q", msg)
+		}
+		if srv.Spools[1].Location != "Closet Shelf" {
+			t.Errorf("spool was modified despite the failure: %q", srv.Spools[1].Location)
+		}
+	})
+
+	// A misconfigured URL reaches Spoolman's web UI, which answers HTTP 200
+	// with HTML (issue #50). That is not a 404, so the version check above does
+	// not catch it, and the unrecognised-shape fallback below would read it as
+	// "the PATCH worked, the count is just unreadable". A rename that never
+	// reached the API must not report success.
+	t.Run("a web page is not a successful rename", func(t *testing.T) {
+		srv := newFakeSpoolman(t)
+		srv.SPAFallback = true
+		srv.Spools = map[int]*fakeSpool{1: {ID: 1, Location: "Closet Shelf"}}
+
+		client := NewSpoolmanClient(srv.URL()+"/not-the-api", 5, "", "")
+		err := client.UpdateLocationByName("Closet Shelf", "Garage")
+		if err == nil {
+			t.Fatal("a web page was reported as a successful rename")
+		}
+		if !strings.Contains(err.Error(), "web page instead of JSON") {
+			t.Errorf("error should explain the misconfiguration, got: %v", err)
+		}
+		if srv.Spools[1].Location != "Closet Shelf" {
+			t.Errorf("spool moved despite the failure: %q", srv.Spools[1].Location)
+		}
+	})
+
+	t.Run("no Unassigned special-casing", func(t *testing.T) {
+		srv := newFakeSpoolman(t)
+		srv.Spools = map[int]*fakeSpool{1: {ID: 1, Location: ""}}
+
+		client := NewSpoolmanClient(srv.URL(), 5, "", "")
+		// "Unassigned" is a display label elsewhere, never a location string.
+		// Renaming it must target that literal name, not the empty string.
+		if err := client.UpdateLocationByName("Unassigned", "Shelf"); err == nil {
+			t.Fatal("expected an error: no spool is in a location named 'Unassigned'")
+		}
+		if srv.Spools[1].Location != "" {
+			t.Errorf("blank-location spool was moved to %q; \"\" must not be treated as \"Unassigned\"", srv.Spools[1].Location)
+		}
+	})
+}
+
 // namesOf extracts the Name field from each location, sorted, for
 // order-independent comparison.
 func namesOf(locs []SpoolmanLocation) []string {

--- a/static/js/nfc.js
+++ b/static/js/nfc.js
@@ -210,12 +210,9 @@ async function loadLocationTags(dataPromise) {
                 <div class="item-info">
                     <div class="item-name">${url.display_name}</div>
                 </div>
-                <!-- Rename disabled until it operates on spools instead of the
-                     abandoned locations setting; restored in a follow-up PR.
                 <div class="location-actions">
                     ${renderLocationActions(url)}
                 </div>
-                -->
             `;
             
             // Add click handler
@@ -417,8 +414,16 @@ async function renameLocation(currentName) {
             body: JSON.stringify({ name: newName.trim() })
         });
         if (!res.ok) {
+            // The API reports failures as {"error": "..."}; show that sentence
+            // rather than the raw JSON envelope. Falls back to the body text if
+            // the response isn't the shape we expect (e.g. a proxy error page).
             const errorText = await res.text();
-            throw new Error(errorText);
+            let message = errorText;
+            try {
+                const parsed = JSON.parse(errorText);
+                if (parsed && parsed.error) message = parsed.error;
+            } catch (_) { /* not JSON — use the raw text */ }
+            throw new Error(message);
         }
         const result = await res.json();
         await loadLocationTags();

--- a/testutil_test.go
+++ b/testutil_test.go
@@ -108,11 +108,14 @@ type fakeSpoolman struct {
 	mu     sync.Mutex
 	Spools map[int]*fakeSpool
 
-	PatchCalls []int    // spool IDs that received usage updates
-	Locations  []string // locations returned by /api/v1/location (the distinct strings spools carry)
+	PatchCalls      []int       // spool IDs that received usage updates
+	Locations       []string    // locations returned by /api/v1/location (the distinct strings spools carry)
+	FieldRenames    [][2]string // {value, new_value} of each PATCH /api/v1/spool/field/location
+	NoFieldEndpoint bool        // simulate pre-v0.26: /api/v1/spool/field/location 404s
 	// SPAFallback makes unrecognised paths answer 200 with the web UI's HTML,
 	// the way real Spoolman does, instead of 404. Opt-in, so tests that rely on
-	// a clean 404 for a genuinely missing endpoint keep working.
+	// a clean 404 for a genuinely missing endpoint keep working — including
+	// NoFieldEndpoint above, which needs that 404 to reach the version check.
 	SPAFallback bool
 
 	srv *httptest.Server
@@ -171,6 +174,31 @@ func (f *fakeSpoolman) handle(w http.ResponseWriter, r *http.Request) {
 		}
 		w.WriteHeader(http.StatusNotFound)
 		fmt.Fprint(w, `{"detail":"no such spool"}`)
+
+	// Bulk field rename (Spoolman v0.26+): rewrites `location` on every spool
+	// carrying `value`. Must precede the /api/v1/spool/{id} PATCH case below,
+	// which would otherwise swallow this path.
+	case r.URL.Path == "/api/v1/spool/field/location" && r.Method == http.MethodPatch:
+		if f.NoFieldEndpoint {
+			// Pre-v0.26 Spoolman: the route does not exist.
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{"detail":"Not Found"}`)
+			return
+		}
+		var body struct {
+			Value    string `json:"value"`
+			NewValue string `json:"new_value"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		f.FieldRenames = append(f.FieldRenames, [2]string{body.Value, body.NewValue})
+		updated := 0
+		for _, sp := range f.Spools {
+			if sp.Location == body.Value {
+				sp.Location = body.NewValue
+				updated++
+			}
+		}
+		writeJSON(w, map[string]int{"spools_updated": updated})
 
 	case strings.HasPrefix(r.URL.Path, "/api/v1/spool/") && r.Method == http.MethodPatch:
 		id := spoolIDFromPath(r.URL.Path)


### PR DESCRIPTION
One of three PRs splitting the old #45. Follows on from the list-only fix (#48), now merged.

## Problem

**Rename is currently disabled.** #48 commented the Rename action out of the Location Tags UI. This PR turns it back on.

It is not a revert. Rename came out because it never worked: `UpdateLocationByName` resolved a location ID and PATCHed `/api/v1/location/{id}`.  That endpoint that no longer exists in v0.26. In previous version the endpoint renamed a record in the `locations` **setting** without updating the associated spool(s). The rename reported success, but the spools remained associated to the old location name.

#48 then sourced locations from `/api/v1/location`, leaving no ID to resolve, so the call could only fail.  Commenting the rename out made PR #48 simpler. 

This PR (re)implements rename by calling `/api/v1/spool/field/location`. This doesn't fix rename with older versions of Spoolman, see version compatibility below.

## Fix

A location is not an entity in Spoolman; it's the free-text `location` field on each spool. So a rename is a bulk field update — exactly what Spoolman's own dashboard group-rename does:

```
PATCH /api/v1/spool/field/location
{"value": "Drybox", "new_value": "Drybox A"}
→ {"spools_updated": 3}
```

Renaming "Drybox" moves every spool in it, in one call.

`UpdateLocation`, which existed only to serve the old ID-based path, is removed.

## A rename that moves nothing is an error

Spoolman returns `200` with `{"spools_updated": 0}` when the old name matched nothing, so the count is read rather than ignored. A rename that moved no spools now returns an error instead of reporting success, which is the bug that caused the rename to be pulled.

`patchJSON` only returned an error, so there was no way to read that count. I added `patchJSONResult`, which returns the response body as well. `patchJSON` now just calls it and ignores the body, so its existing callers didn't have to change.

## Version compatibility

`PATCH /api/v1/spool/field/location` is **new in Spoolman v0.26.0** and absent in v0.25.x, where it 404s. Everything else in FilaBridge works against older versions.

A 404 from a versioned endpoint means "this server is too old", not "your request was wrong". Rather than surfacing a bare HTTP error, the rename says:

> renaming locations requires Spoolman v0.26.0 or newer; this server does not support it

To distinguish that case, `handleAPIError` now returns a typed `SpoolmanAPIError` carrying the status code. Its message is byte-identical to before and callers that only need an `error` are unaffected. It just stops the status code being available *only* as text inside a formatted string.

This is deliberately error-based rather than version-based: the 404 proves the endpoint is absent, whereas parsing `"0.26.0"` infers it, and that inference breaks on release candidates, `-dev` builds, and forks.

**No per-spool fallback is implemented.** `renameLocationBulk` is the only code that touches the endpoint, and carries a `TODO(spoolman-compat)` describing the approach if you want one: `GET /api/v1/spool?location=<old>` then `PATCH /api/v1/spool/{id}` per spool, available since at least v0.21. Adding it means editing that one function; nothing else moves. Happy to build it into this PR if you want to get rename working on older servers instead of explaining why it doesn't.

README documents the version requirement and what a rename actually does.

## Known limitation: Spoolman's dashboard keeps the old card

Renaming moves the spools correctly, but Spoolman's dashboard continues to show the **old** name as an empty group card.

That's because there is a third thing called "location" in v0.26, distinct from both `/api/v1/location` and the legacy `locations` setting: the `dashboard_groups` setting, which stores the dashboard's card layout. On a live instance after two renames it looked like this:

```json
{"location":["MK4S - Toolhead 0","Core One - Toolhead 0","Closet Shellfs","Closet Shelfs","Closet Shelf"],
 "extra.card_uids":["046AF377CD2A81"]}
```

Three of those names have no spools in them. They are leftovers from earlier renames. Nothing prunes the list, and `PATCH /api/v1/spool/field/location` doesn't touch it, so a renamed location's old card stays until it's removed in Spoolman's UI. FilaBridge's own location list is unaffected; it reads `/api/v1/location`, so it shows only real locations (meaning has a spool).

Spoolman's own group-rename presumably updates `dashboard_groups` alongside the spools, which is why renaming there doesn't leave a card behind.

**I've deliberately not done that here.** Updating `dashboard_groups` means FilaBridge writing Spoolman's dashboard layout. That would be a read-modify-write on a JSON-encoded setting, with a clobber risk if anything edits it concurrently. I chose to not do it because it shades into the location curation / stale-name cleanup you said you wanted to own separately. It's a small addition inside `renameLocationBulk` if you'd rather rename be a complete match for Spoolman's.  

## Follow-up this enables: printer and toolhead renames

Toolhead location strings are derived from config (`"<printer> - <toolhead>"`), so renaming either end changes what the location is *called* while spools keep carrying the old string. The two paths handle that inconsistently today:

- **Toolhead rename alone** (`SetToolheadName`, `bridge.go`) migrates correctly: it computes the old and new location names, walks every spool, and moves the matching ones. It predates this PR — but it's an N+1 loop over the full spool list, which is exactly what `UpdateLocationByName` now does in one call.
- **Printer rename** (`updatePrinterHandler`, `web.go`) does **not** migrate anything. It saves the config and reloads. Every spool in `"OldName - Toolhead 0"` is stranded there permanently, while FilaBridge starts deriving `"NewName - Toolhead 0"`.
- **Printer rename followed by a toolhead rename** is worse than either. `SetToolheadName` builds the old location name from the printer's *current* config name, which by then is already the new one — so it searches for `"NewPrinter - Toolhead 0"`, matches nothing, and reports success. A printer rename therefore breaks the toolhead migration too; that path only works on a printer that has never been renamed.

These are pre-existing and unrelated to this PR, but worth flagging because they become *more visible* alongside the toolhead-tag PR in this series: after a printer rename you'd see the orphaned `"OldName - Toolhead 0"` listed as a **storage** location (it no longer matches any configured toolhead, but spools still carry it), next to a brand-new empty tag for `"NewName - Toolhead 0"`. Both stale entries would also linger as dashboard cards, per the limitation above.

The fix is tractable — the old location name just has to come from the printer's *previous* name, which `updatePrinterHandler` already has on hand, and the toolhead-to-location mapping is 1:1 so there's exactly one correct old name.

This PR doesn't fix either — it's out of scope, and printer rename deserves its own change with its own tests. But it supplies the piece that was missing: a rename that actually moves spools. Wiring `updatePrinterHandler` to call it, and simplifying `SetToolheadName` to use it instead of the per-spool loop, is a natural follow-up. Happy to take it on if you want it.

## Error messages now reach the user as sentences

The Location Tags UI alerted the raw response body, so **any** rename failure appeared as:

```
{"error":"no spools are in location 'Drybox'"}
```

It now parses the envelope and shows the message, falling back to the raw text if the response isn't the expected shape. This matters most for the zero-match case above, which ordinary users will hit — not just for old servers.

## Testing

`go build ./...`, `go vet ./...`, `go test ./...` green; `gofmt` clean.

`TestUpdateLocationByName` covers five things:

- every spool carrying the old name moves; unrelated spools don't
- the call is the **bulk field update**, asserted on the request body, with no per-spool PATCH (the old behavior)
- zero matches → error, and nothing modified
- renaming `"Unassigned"` errors and leaves blank-location spools alone
- a missing endpoint reports the version requirement, and does **not** leak `404` into the message

The fake Spoolman gained a `PATCH /api/v1/spool/field/location` case returning `{"spools_updated": N}`. It records each `{value, new_value}` so the request body can be asserted rather than inferred from side effects, and a `NoFieldEndpoint` flag makes it 404 that route to stand in for a pre-v0.26 server.

All three new guarantees were mutation-tested — removing the zero-check, reintroducing the `"Unassigned"` mapping, and making the 404 branch unreachable each make the suite fail. The last one fails with `spoolman API error (HTTP 404):  - Not Found`, which is precisely the message this change exists to replace.

Also verified against a **real pre-v0.26 Spoolman instance**, not just the fake: attempting a rename fails with the version message rather than a raw HTTP error. That confirms the assumption the branch rests on — that older Spoolman answers this endpoint with a 404 rather than a 405 or 422.

