### PR TITLE
feat: Support Configurable Reverse Proxy Paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,28 @@ FilaBridge is built to run as a Docker container or a Linux service alongside a 
 
 FilaBridge is designed for use on a private, trusted network and has no built-in authentication. Stored credentials (PrusaLink API keys and the optional Spoolman password) are write-only: the API and UI never return them once saved. However, anyone who can reach the web interface can still change settings - including pointing FilaBridge at servers they control - so treat interface access as full control. Do not expose FilaBridge directly to the internet. If you need remote access, put it behind a VPN or an authenticating reverse proxy.
 
+FilaBridge can be mounted below a path-prefixed reverse proxy by setting
+`FILABRIDGE_BASE_PATH` to its browser-visible application root, for example
+`/filabridge`. The setting is optional; leave it unset to continue serving at
+`/`. When configured, FilaBridge serves its interface, static assets, API,
+WebSocket, and NFC endpoints beneath that fixed path. The proxy must preserve
+the prefix when forwarding, or add it back before requests reach FilaBridge if
+the proxy strips it. Proxies should also set `X-Forwarded-Host` and
+`X-Forwarded-Proto` so generated NFC tag URLs use the browser-visible host and
+the correct `http` or `https` scheme.
+
 ## Configuration
 
-The system stores all configuration in the SQLite database. For Docker deployments, you can optionally set the `FILABRIDGE_DB_PATH` environment variable to specify where the database should be stored (defaults to `/app/data` in Docker), however I recommend leaving it as is and changing the volume mount instead, if needed.
+The system stores application configuration in the SQLite database. A small
+set of process-level settings is available through environment variables;
+changes to these require a restart:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `FILABRIDGE_DB_PATH` | `/app/data` in Docker; current directory for a binary | Directory containing `filabridge.db`. For Docker, prefer changing the volume mount instead. |
+| `FILABRIDGE_BASE_PATH` | empty | Optional fixed reverse-proxy mount path, such as `/filabridge`. A leading slash is optional and a trailing slash is removed. |
+| `FILABRIDGE_OLD_UI` | `false` | Use the pre-1.2.2 interface styling. |
+| `FILABRIDGE_DEVELOPER_MODE` | `false` | Enable incomplete development features such as Bambu Lab support. |
 
 ### First Run
 

--- a/config.go
+++ b/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	pathpkg "path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -41,6 +42,7 @@ type Config struct {
 	Printers                     map[string]PrinterConfig // Key is printer ID, value is printer config
 	DeveloperMode                bool                     // Experimental features (e.g. Bambu support) via FILABRIDGE_DEVELOPER_MODE
 	LegacyUI                     bool                     // Serve the pre-1.2.2 interface via FILABRIDGE_OLD_UI
+	BasePath                     string                   // Optional reverse-proxy mount path via FILABRIDGE_BASE_PATH
 }
 
 // LoadConfig loads configuration from database
@@ -69,6 +71,7 @@ func LoadConfig(bridge *FilamentBridge) (*Config, error) {
 		Printers:                     make(map[string]PrinterConfig),
 		DeveloperMode:                developerModeEnabled(),
 		LegacyUI:                     legacyUIEnabled(),
+		BasePath:                     configuredBasePath(),
 	}
 
 	// Load printer configs directly from database without making API calls.
@@ -104,6 +107,25 @@ func developerModeEnabled() bool {
 // once the new interface has a few releases behind it.
 func legacyUIEnabled() bool {
 	return envFlagEnabled("FILABRIDGE_OLD_UI")
+}
+
+// configuredBasePath returns the fixed path at which FilaBridge is mounted.
+// An empty value keeps the application at the site root. As with Spoolman's
+// SPOOLMAN_BASE_PATH, operators may omit the leading slash and any trailing
+// slash is removed.
+func configuredBasePath() string {
+	raw := strings.TrimSpace(os.Getenv("FILABRIDGE_BASE_PATH"))
+	if raw == "" || raw == "/" {
+		return ""
+	}
+	if !strings.HasPrefix(raw, "/") {
+		raw = "/" + raw
+	}
+	cleaned := pathpkg.Clean(raw)
+	if cleaned == "." || cleaned == "/" {
+		return ""
+	}
+	return cleaned
 }
 
 // envFlagEnabled reads a boolean environment variable, accepting the spellings

--- a/static/css/v2/tokens.css
+++ b/static/css/v2/tokens.css
@@ -114,7 +114,7 @@
     font-style: normal;
     font-weight: 400;
     font-display: swap;
-    src: url('/static/fonts/ibm-plex-sans-400.woff2') format('woff2');
+    src: url('../../fonts/ibm-plex-sans-400.woff2') format('woff2');
 }
 
 @font-face {
@@ -122,7 +122,7 @@
     font-style: normal;
     font-weight: 500;
     font-display: swap;
-    src: url('/static/fonts/ibm-plex-sans-500.woff2') format('woff2');
+    src: url('../../fonts/ibm-plex-sans-500.woff2') format('woff2');
 }
 
 @font-face {
@@ -130,7 +130,7 @@
     font-style: normal;
     font-weight: 600;
     font-display: swap;
-    src: url('/static/fonts/ibm-plex-sans-600.woff2') format('woff2');
+    src: url('../../fonts/ibm-plex-sans-600.woff2') format('woff2');
 }
 
 @font-face {
@@ -138,7 +138,7 @@
     font-style: normal;
     font-weight: 700;
     font-display: swap;
-    src: url('/static/fonts/ibm-plex-sans-700.woff2') format('woff2');
+    src: url('../../fonts/ibm-plex-sans-700.woff2') format('woff2');
 }
 
 @font-face {
@@ -146,7 +146,7 @@
     font-style: normal;
     font-weight: 400;
     font-display: swap;
-    src: url('/static/fonts/ibm-plex-mono-400.woff2') format('woff2');
+    src: url('../../fonts/ibm-plex-mono-400.woff2') format('woff2');
 }
 
 @font-face {
@@ -154,7 +154,7 @@
     font-style: normal;
     font-weight: 500;
     font-display: swap;
-    src: url('/static/fonts/ibm-plex-mono-500.woff2') format('woff2');
+    src: url('../../fonts/ibm-plex-mono-500.woff2') format('woff2');
 }
 
 /* Base document. Upstream runs a 13px base with a dense type scale; the classic

--- a/static/js/dropdowns.js
+++ b/static/js/dropdowns.js
@@ -43,7 +43,7 @@ async function loadAvailableSpools(dropdown) {
     const printerName = printerNameElement.textContent;
     
     try {
-        const response = await fetch(`/api/available_spools?printer_name=${encodeURIComponent(printerName)}&toolhead_id=${toolheadId}`);
+        const response = await fetch(apiUrl(`/api/available_spools?printer_name=${encodeURIComponent(printerName)}&toolhead_id=${toolheadId}`));
         const data = await response.json();
         
         if (data.error) {
@@ -302,7 +302,7 @@ async function autoMapSpool(dropdown, selectedValue, selectedText, selectedColor
     setDropdownButton(button, selectedColor, selectedMulti, selectedText, '⏳');
     
     try {
-        const response = await fetch('/api/map_toolhead', {
+        const response = await fetch(apiUrl('/api/map_toolhead'), {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify({

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -137,8 +137,8 @@ async function loadPrintHistory() {
         // Fetch history and spools together; spools are only used to show
         // friendly names, so a spool that no longer exists falls back to its ID
         const [historyRes, spoolsRes] = await Promise.all([
-            fetch('/api/print-history'),
-            fetch('/api/spools').catch(() => null)
+            fetch(apiUrl('/api/print-history')),
+            fetch(apiUrl('/api/spools')).catch(() => null)
         ]);
         const historyData = await historyRes.json();
 
@@ -261,7 +261,7 @@ function switchSettingsTab(tabName, clickedElement) {
 
 // Configuration Management
 function loadConfiguration() {
-    fetch('/api/config')
+    fetch(apiUrl('/api/config'))
         .then(response => response.json())
         .then(config => {
             const form = document.getElementById('config-form');
@@ -334,7 +334,7 @@ async function apiRequest(url, options = {}) {
         opts.headers = { 'Content-Type': 'application/json', ...(opts.headers || {}) };
         opts.body = JSON.stringify(opts.body);
     }
-    const response = await fetch(url, opts);
+    const response = await fetch(apiUrl(url), opts);
     const data = await response.json();
     if (data.error) {
         throw new Error(data.error);
@@ -370,7 +370,7 @@ function saveConfiguration() {
 
 // Advanced Settings Functions
 function loadAdvancedSettings() {
-    fetch('/api/config')
+    fetch(apiUrl('/api/config'))
         .then(response => response.json())
         .then(config => {
             document.getElementById('prusalinkTimeout').value = config.prusalink_timeout || '10';
@@ -427,7 +427,7 @@ let autoAssignCheckboxHandler = null;
 
 function loadAutoAssignSettings() {
     // First, load the settings
-    fetch('/api/config/auto-assign-previous-spool')
+    fetch(apiUrl('/api/config/auto-assign-previous-spool'))
         .then(response => response.json())
         .then(data => {
             if (data.error) {
@@ -450,7 +450,7 @@ function loadAutoAssignSettings() {
             setAutoAssignOptionsVisible(enabled);
 
             // Load locations and populate dropdown
-            return fetch('/api/locations')
+            return fetch(apiUrl('/api/locations'))
                 .then(response => response.json())
                 .then(locationsData => {
                     if (locationsData.error) {
@@ -560,7 +560,7 @@ let printHistoryWasEnabled = true;
 
 // NFC Scanning Settings Functions
 function loadNFCScanningSettings() {
-    fetch('/api/config/nfc-toolhead-unload')
+    fetch(apiUrl('/api/config/nfc-toolhead-unload'))
         .then(response => response.json())
         .then(data => {
             const checkbox = document.getElementById('nfcToolheadFirstUnloads');
@@ -586,7 +586,7 @@ function saveNFCScanningSettings() {
 }
 
 function loadPrintHistorySettings() {
-    fetch('/api/config/print-history')
+    fetch(apiUrl('/api/config/print-history'))
         .then(response => response.json())
         .then(data => {
             const checkbox = document.getElementById('printHistoryEnabled');
@@ -693,11 +693,9 @@ function isDeveloperMode() {
 }
 
 function apiUrl(path) {
-    // Ensure path starts with / if not already
-    if (!path.startsWith('/')) {
-        path = '/' + path;
-    }
-    return `${window.location.origin}${path}`;
+    // The document base is supplied by the server. It is "/" for direct
+    // access and Home Assistant's generated prefix when served via Ingress.
+    return new URL(path.replace(/^\/+/, ''), document.baseURI).toString();
 }
 
 // swatchBackground returns a CSS background value for a filament swatch: a

--- a/static/js/nfc.js
+++ b/static/js/nfc.js
@@ -40,7 +40,7 @@ function switchNfcTab(tabName, clickedElement) {
 
 // fetchNfcUrls fetches all NFC tag URLs (spools, filaments, locations) in one call
 async function fetchNfcUrls() {
-    const response = await fetch('/api/nfc/urls');
+    const response = await fetch(apiUrl('/api/nfc/urls'));
     return response.json();
 }
 
@@ -202,7 +202,7 @@ async function loadLocationTags(dataPromise) {
             let icon = '📦'; // Storage icon for storage locations
             let iconHtml = icon;
             if (url.location_type === 'printer') {
-                iconHtml = '<img src="/static/images/3d-printer-icon.png" alt="3D Printer" style="width: 20px; height: 20px;">';
+                iconHtml = `<img src="${apiUrl('/static/images/3d-printer-icon.png')}" alt="3D Printer" style="width: 20px; height: 20px;">`;
             }
             
             item.innerHTML = `
@@ -430,4 +430,3 @@ async function renameLocation(currentName) {
         alert(e.message || 'Network error'); 
     }
 }
-

--- a/static/js/printers.js
+++ b/static/js/printers.js
@@ -10,7 +10,7 @@ function escapeHtmlAttribute(value) {
 
 // Printer Management Functions
 function loadPrinters() {
-    fetch('/api/printers')
+    fetch(apiUrl('/api/printers'))
         .then(response => response.json())
         .then(data => {
             const printerList = document.getElementById('printer-list');
@@ -293,7 +293,7 @@ document.getElementById('editPrinterForm').addEventListener('submit', function(e
 
 function editPrinter(printerId) {
     // Get the current printer data
-    fetch('/api/printers')
+    fetch(apiUrl('/api/printers'))
         .then(response => response.json())
         .then(data => {
             const printer = data.printers[printerId];

--- a/static/js/websocket.js
+++ b/static/js/websocket.js
@@ -7,11 +7,11 @@ let maxReconnectAttempts = 10;
 let reconnectDelay = 1000; // Start with 1 second
 
 function connectWebSocket() {
-    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-    const wsUrl = `${protocol}//${window.location.host}/ws/status`;
+    const wsUrl = new URL('ws/status', document.baseURI);
+    wsUrl.protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
     
     try {
-        ws = new WebSocket(wsUrl);
+        ws = new WebSocket(wsUrl.toString());
         
         ws.onopen = function(event) {
             console.log('WebSocket connected');
@@ -436,7 +436,7 @@ async function assignMappingWarning(warningId) {
     if (Number.isNaN(toolheadId)) return;
 
     try {
-        const response = await fetch(`/api/mapping-warnings/${encodeURIComponent(warningId)}/assign`, {
+        const response = await fetch(apiUrl(`/api/mapping-warnings/${encodeURIComponent(warningId)}/assign`), {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ toolhead_id: toolheadId }),
@@ -462,7 +462,7 @@ async function assignMappingWarning(warningId) {
 // Acknowledge an unknown-filament-slot warning
 async function acknowledgeMappingWarning(warningId) {
     try {
-        const response = await fetch(`/api/mapping-warnings/${encodeURIComponent(warningId)}/acknowledge`, {
+        const response = await fetch(apiUrl(`/api/mapping-warnings/${encodeURIComponent(warningId)}/acknowledge`), {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
         });
@@ -485,7 +485,7 @@ async function acknowledgeMappingWarning(warningId) {
 // Acknowledge a low-filament warning (resumes the print if it was auto-paused)
 async function acknowledgeRunoutWarning(warningId) {
     try {
-        const response = await fetch(`/api/runout-warnings/${encodeURIComponent(warningId)}/acknowledge`, {
+        const response = await fetch(apiUrl(`/api/runout-warnings/${encodeURIComponent(warningId)}/acknowledge`), {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
         });
@@ -544,7 +544,7 @@ function updatePrintErrors(printErrors) {
 // Acknowledge print error
 async function acknowledgeError(errorId) {
     try {
-        const response = await fetch(`/api/print-errors/${encodeURIComponent(errorId)}/acknowledge`, {
+        const response = await fetch(apiUrl(`/api/print-errors/${encodeURIComponent(errorId)}/acknowledge`), {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,30 +5,31 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="FilaBridge - The missing link between printers and filament inventory">
     <meta name="theme-color" content="{{if .LegacyUI}}#667eea{{else}}#1f1f1f{{end}}">
+    <base href="{{.BasePath}}">
     <title>FilaBridge Dashboard</title>
-    <link rel="icon" type="image/svg+xml" href="/static/images/favicon.svg">
+    <link rel="icon" type="image/svg+xml" href="{{.BasePath}}static/images/favicon.svg">
     <!-- External CSS Files -->
-    <link rel="stylesheet" href="/static/css/main.css">
-    <link rel="stylesheet" href="/static/css/components.css">
-    <link rel="stylesheet" href="/static/css/dropdowns.css">
-    <link rel="stylesheet" href="/static/css/tabs.css">
-    <link rel="stylesheet" href="/static/css/printers.css">
-    <link rel="stylesheet" href="/static/css/nfc.css">
-    <link rel="stylesheet" href="/static/css/modals.css">
+    <link rel="stylesheet" href="{{.BasePath}}static/css/main.css">
+    <link rel="stylesheet" href="{{.BasePath}}static/css/components.css">
+    <link rel="stylesheet" href="{{.BasePath}}static/css/dropdowns.css">
+    <link rel="stylesheet" href="{{.BasePath}}static/css/tabs.css">
+    <link rel="stylesheet" href="{{.BasePath}}static/css/printers.css">
+    <link rel="stylesheet" href="{{.BasePath}}static/css/nfc.css">
+    <link rel="stylesheet" href="{{.BasePath}}static/css/modals.css">
     {{if not .LegacyUI}}
     <!-- The current interface, matching Spoolman's redesigned (client_v2) look.
          Loaded last so it restyles the sheets above rather than replacing them:
          same markup, same behaviour, only the styling differs. Set
          FILABRIDGE_OLD_UI=true to skip these and get the pre-1.2.2 look back. -->
-    <link rel="stylesheet" href="/static/css/v2/tokens.css">
-    <link rel="stylesheet" href="/static/css/v2/shell.css">
-    <link rel="stylesheet" href="/static/css/v2/components.css">
-    <link rel="stylesheet" href="/static/css/v2/nfc.css">
+    <link rel="stylesheet" href="{{.BasePath}}static/css/v2/tokens.css">
+    <link rel="stylesheet" href="{{.BasePath}}static/css/v2/shell.css">
+    <link rel="stylesheet" href="{{.BasePath}}static/css/v2/components.css">
+    <link rel="stylesheet" href="{{.BasePath}}static/css/v2/nfc.css">
     {{end}}
 
     <!-- Preload critical JavaScript -->
-    <link rel="preload" href="/static/js/main.js" as="script">
-    <link rel="preload" href="/static/js/dropdowns.js" as="script">
+    <link rel="preload" href="{{.BasePath}}static/js/main.js" as="script">
+    <link rel="preload" href="{{.BasePath}}static/js/dropdowns.js" as="script">
 </head>
 <body data-spoolman-url="{{.SpoolmanBaseURL}}" data-developer-mode="{{.DeveloperMode}}">
     <div class="container">
@@ -61,10 +62,10 @@
     {{template "modals" .}}
 
     <!-- External JavaScript Files -->
-    <script src="/static/js/main.js"></script>
-    <script src="/static/js/dropdowns.js"></script>
-    <script src="/static/js/printers.js"></script>
-    <script src="/static/js/websocket.js"></script>
-    <script src="/static/js/nfc.js"></script>
+    <script src="{{.BasePath}}static/js/main.js"></script>
+    <script src="{{.BasePath}}static/js/dropdowns.js"></script>
+    <script src="{{.BasePath}}static/js/printers.js"></script>
+    <script src="{{.BasePath}}static/js/websocket.js"></script>
+    <script src="{{.BasePath}}static/js/nfc.js"></script>
 </body>
 </html>

--- a/templates/error.html
+++ b/templates/error.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <base href="{{.BasePath}}">
     <title>FilaBridge - Error</title>
     <style>
         body {
@@ -39,15 +40,15 @@
     <!-- Current Spoolman-style interface. Loaded after the block above so it
          overrides it without the page needing two copies. Set
          FILABRIDGE_OLD_UI=true for the pre-1.2.2 look. -->
-    <link rel="stylesheet" href="/static/css/v2/tokens.css">
-    <link rel="stylesheet" href="/static/css/v2/standalone.css">
+    <link rel="stylesheet" href="{{.BasePath}}static/css/v2/tokens.css">
+    <link rel="stylesheet" href="{{.BasePath}}static/css/v2/standalone.css">
     {{end}}
 </head>
 <body>
     <div class="error-box">
         <h1>Something went wrong</h1>
         <p>{{.Error}}</p>
-        <a href="/">Back to Dashboard</a>
+        <a href="{{.BasePath}}">Back to Dashboard</a>
     </div>
 </body>
 </html>

--- a/templates/nfc_error.html
+++ b/templates/nfc_error.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <base href="{{.BasePath}}">
     <title>NFC Error - FilaBridge</title>
     <style>
         body {
@@ -60,8 +61,8 @@
     <!-- Current Spoolman-style interface. Loaded after the block above so it
          overrides it without the page needing two copies. Set
          FILABRIDGE_OLD_UI=true for the pre-1.2.2 look. -->
-    <link rel="stylesheet" href="/static/css/v2/tokens.css">
-    <link rel="stylesheet" href="/static/css/v2/standalone.css">
+    <link rel="stylesheet" href="{{.BasePath}}static/css/v2/tokens.css">
+    <link rel="stylesheet" href="{{.BasePath}}static/css/v2/standalone.css">
     {{end}}
 </head>
 <body>
@@ -69,7 +70,7 @@
         <div class="error-icon">⚠️</div>
         <h1>NFC Error</h1>
         <div class="error-message">{{.Error}}</div>
-        <a href="/" class="back-button">Back to Dashboard</a>
+        <a href="{{.BasePath}}" class="back-button">Back to Dashboard</a>
     </div>
 </body>
 </html>

--- a/templates/nfc_progress.html
+++ b/templates/nfc_progress.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <base href="{{.BasePath}}">
     <title>NFC Scan Progress - FilaBridge</title>
     <style>
         body {
@@ -95,8 +96,8 @@
     <!-- Current Spoolman-style interface. Loaded after the block above so it
          overrides it without the page needing two copies. Set
          FILABRIDGE_OLD_UI=true for the pre-1.2.2 look. -->
-    <link rel="stylesheet" href="/static/css/v2/tokens.css">
-    <link rel="stylesheet" href="/static/css/v2/standalone.css">
+    <link rel="stylesheet" href="{{.BasePath}}static/css/v2/tokens.css">
+    <link rel="stylesheet" href="{{.BasePath}}static/css/v2/standalone.css">
     {{end}}
 </head>
 <body>
@@ -114,7 +115,7 @@
                 <div class="step-text">Scan location tag</div>
             </div>
         </div>
-        <a href="/" class="back-button">Back to Dashboard</a>
+        <a href="{{.BasePath}}" class="back-button">Back to Dashboard</a>
     </div>
 </body>
 </html>

--- a/templates/nfc_success.html
+++ b/templates/nfc_success.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <base href="{{.BasePath}}">
     <title>{{if .Unloaded}}NFC Unload Complete{{else}}NFC Assignment Complete{{end}} - FilaBridge</title>
     <style>
         body {
@@ -85,8 +86,8 @@
     <!-- Current Spoolman-style interface. Loaded after the block above so it
          overrides it without the page needing two copies. Set
          FILABRIDGE_OLD_UI=true for the pre-1.2.2 look. -->
-    <link rel="stylesheet" href="/static/css/v2/tokens.css">
-    <link rel="stylesheet" href="/static/css/v2/standalone.css">
+    <link rel="stylesheet" href="{{.BasePath}}static/css/v2/tokens.css">
+    <link rel="stylesheet" href="{{.BasePath}}static/css/v2/standalone.css">
     {{end}}
 </head>
 <body>
@@ -149,7 +150,7 @@
             {{end}}
         </div>
         {{end}}
-        <a href="/" class="back-button">Back to Dashboard</a>
+        <a href="{{.BasePath}}" class="back-button">Back to Dashboard</a>
     </div>
 </body>
 </html>

--- a/web.go
+++ b/web.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net/http"
 	neturl "net/url"
+	pathpkg "path"
 	"sort"
 	"strconv"
 	"strings"
@@ -31,6 +32,7 @@ var staticFS embed.FS
 type WebServer struct {
 	bridge         *FilamentBridge
 	router         *gin.Engine
+	basePath       string
 	operationMutex sync.Mutex // Protects add/update/delete printer operations
 	wsHub          *WebSocketHub
 }
@@ -67,13 +69,20 @@ type WebSocketMessage struct {
 func NewWebServer(bridge *FilamentBridge) *WebServer {
 	gin.SetMode(gin.ReleaseMode)
 	router := gin.New()
+	basePath := ""
+	if cfg := bridge.GetConfigSnapshot(); cfg != nil {
+		basePath = cfg.BasePath
+	}
+	healthPath := basePath + "/healthz"
+	apiPath := basePath + "/api/"
+	staticPath := basePath + "/static/"
 
 	// Add middleware. Request logging skips the healthcheck endpoint (hit every
 	// 30s by Docker) and static assets, which would otherwise dominate the log.
 	router.Use(gin.LoggerWithConfig(gin.LoggerConfig{
-		SkipPaths: []string{"/healthz"},
+		SkipPaths: []string{"/healthz", healthPath},
 		Skip: func(c *gin.Context) bool {
-			return strings.HasPrefix(c.Request.URL.Path, "/static/")
+			return strings.HasPrefix(c.Request.URL.Path, staticPath)
 		},
 	}))
 	router.Use(gin.Recovery())
@@ -83,7 +92,7 @@ func NewWebServer(bridge *FilamentBridge) *WebServer {
 		defer func() {
 			if err := recover(); err != nil {
 				// Check if this is an API route
-				if strings.HasPrefix(c.Request.URL.Path, "/api/") {
+				if strings.HasPrefix(c.Request.URL.Path, apiPath) {
 					c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
 					c.Abort()
 				} else {
@@ -104,9 +113,10 @@ func NewWebServer(bridge *FilamentBridge) *WebServer {
 	}
 
 	ws := &WebServer{
-		bridge: bridge,
-		router: router,
-		wsHub:  wsHub,
+		bridge:   bridge,
+		router:   router,
+		basePath: basePath,
+		wsHub:    wsHub,
 	}
 
 	// Start WebSocket hub
@@ -139,16 +149,22 @@ func (ws *WebServer) setupRoutes() {
 	if err != nil {
 		log.Fatalf("Failed to create static filesystem: %v", err)
 	}
-	ws.router.StaticFS("/static", http.FS(staticSubFS))
+	routes := ws.router.Group(ws.basePath)
+	routes.StaticFS("/static", http.FS(staticSubFS))
 
 	// Main dashboard
-	ws.router.GET("/", ws.dashboardHandler)
+	routes.GET("/", ws.dashboardHandler)
 
 	// Liveness probe for Docker/compose healthchecks and monitoring
-	ws.router.GET("/healthz", ws.healthzHandler)
+	routes.GET("/healthz", ws.healthzHandler)
+	if ws.basePath != "" {
+		// Keep the operational healthcheck at the site root so the image's
+		// built-in Docker HEALTHCHECK works for every configured base path.
+		ws.router.GET("/healthz", ws.healthzHandler)
+	}
 
 	// API routes
-	api := ws.router.Group("/api")
+	api := routes.Group("/api")
 	{
 		api.GET("/status", ws.statusHandler)
 		api.GET("/spools", ws.spoolsHandler)
@@ -187,7 +203,7 @@ func (ws *WebServer) setupRoutes() {
 	}
 
 	// WebSocket endpoint
-	ws.router.GET("/ws/status", ws.websocketHandler)
+	routes.GET("/ws/status", ws.websocketHandler)
 }
 
 // WebSocket hub methods
@@ -440,6 +456,7 @@ func (ws *WebServer) dashboardHandler(c *gin.Context) {
 		"SpoolmanBaseURL":    cfg.SpoolmanURL,
 		"DeveloperMode":      cfg.DeveloperMode,
 		"LegacyUI":           cfg.LegacyUI,
+		"BasePath":           ws.browserBasePath(),
 	})
 }
 
@@ -460,14 +477,62 @@ func internalError(c *gin.Context, err error) {
 	c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 }
 
+// browserBasePath is the configured mount path with the trailing slash HTML
+// base URLs require. Direct deployments use the site root.
+func (ws *WebServer) browserBasePath() string {
+	if ws.basePath == "" {
+		return "/"
+	}
+	return ws.basePath + "/"
+}
+
+// requestScheme returns the browser-facing request scheme. Reverse proxies
+// terminate TLS before FilaBridge, so prefer their first X-Forwarded-Proto
+// value and otherwise fall back to the direct connection.
+func requestScheme(r *http.Request) string {
+	if forwarded := r.Header.Get("X-Forwarded-Proto"); forwarded != "" {
+		scheme := strings.ToLower(strings.TrimSpace(strings.Split(forwarded, ",")[0]))
+		if scheme == "http" || scheme == "https" {
+			return scheme
+		}
+	}
+	if r.TLS != nil {
+		return "https"
+	}
+	return "http"
+}
+
+func requestHost(r *http.Request) string {
+	if forwarded := r.Header.Get("X-Forwarded-Host"); forwarded != "" {
+		if host := strings.TrimSpace(strings.Split(forwarded, ",")[0]); host != "" {
+			return host
+		}
+	}
+	return r.Host
+}
+
+// requestAppURL builds a browser-facing URL for routes represented in QR/NFC
+// tags. It includes the configured mount path while preserving direct HTTP and
+// HTTPS deployments.
+func (ws *WebServer) requestAppURL(r *http.Request, route string, rawQuery string) string {
+	u := neturl.URL{
+		Scheme:   requestScheme(r),
+		Host:     requestHost(r),
+		Path:     pathpkg.Join(ws.basePath, route),
+		RawQuery: rawQuery,
+	}
+	return u.String()
+}
+
 // renderPage renders one of the standalone pages (the NFC scan results and the
 // error page), adding the fields every page needs on top of the handler's own
-// data. Currently that is LegacyUI, which selects the pre-1.2.2 interface; the
-// dashboard passes it explicitly since it already builds a full data map.
+// data. The dashboard passes these explicitly since it already builds a full
+// data map.
 func (ws *WebServer) renderPage(c *gin.Context, code int, name string, data gin.H) {
 	if data == nil {
 		data = gin.H{}
 	}
+	data["BasePath"] = ws.browserBasePath()
 	if cfg := ws.bridge.GetConfigSnapshot(); cfg != nil {
 		data["LegacyUI"] = cfg.LegacyUI
 	}
@@ -1587,7 +1652,7 @@ func (ws *WebServer) nfcUrlsHandler(c *gin.Context) {
 
 	// Generate spool URLs
 	for _, spool := range spools {
-		url := fmt.Sprintf("http://%s/api/nfc/assign?spool=%d", c.Request.Host, spool.ID)
+		url := ws.requestAppURL(c.Request, "/api/nfc/assign", fmt.Sprintf("spool=%d", spool.ID))
 
 		// Optional single-scan quick-assign variant (see quickAssignLocation above)
 		comboURL := ""
@@ -1598,8 +1663,8 @@ func (ws *WebServer) nfcUrlsHandler(c *gin.Context) {
 			// result, but a spool-first URL also reads correctly to anyone
 			// inspecting a tag, and never looks like the lone toolhead scan that
 			// the "toolhead tag first unloads" mode treats as an unload.
-			comboURL = fmt.Sprintf("http://%s/api/nfc/assign?spool=%d&location=%s",
-				c.Request.Host, spool.ID, neturl.QueryEscape(quickAssignLocation))
+			comboURL = ws.requestAppURL(c.Request, "/api/nfc/assign", fmt.Sprintf("spool=%d&location=%s",
+				spool.ID, neturl.QueryEscape(quickAssignLocation)))
 			if qrCode, err := qrcode.Encode(comboURL, qrcode.Medium, 256); err != nil {
 				log.Printf("Error generating quick-assign QR code for spool %d: %v", spool.ID, err)
 			} else {
@@ -1723,7 +1788,7 @@ func (ws *WebServer) nfcUrlsHandler(c *gin.Context) {
 		}
 
 		locationParam := location.Name
-		nfcUrl := fmt.Sprintf("http://%s/api/nfc/assign?location=%s", c.Request.Host, neturl.QueryEscape(locationParam))
+		nfcUrl := ws.requestAppURL(c.Request, "/api/nfc/assign", "location="+neturl.QueryEscape(locationParam))
 
 		// Generate QR code (leave it empty and keep going if generation fails)
 		qrCodeBase64 := ""

--- a/web_test.go
+++ b/web_test.go
@@ -12,7 +12,12 @@ import (
 )
 
 func newTestServer(t *testing.T) (*WebServer, *fakePrusaLink, *fakeSpoolman) {
+	return newTestServerAtBasePath(t, "")
+}
+
+func newTestServerAtBasePath(t *testing.T, basePath string) (*WebServer, *fakePrusaLink, *fakeSpoolman) {
 	t.Helper()
+	t.Setenv("FILABRIDGE_BASE_PATH", basePath)
 	printer := newFakePrusaLink(t)
 	spoolman := newFakeSpoolman(t)
 	bridge := newTestBridge(t, printer, spoolman)
@@ -37,6 +42,163 @@ func doJSON(t *testing.T, ws *WebServer, method, path, body string) (*httptest.R
 	var parsed map[string]interface{}
 	json.Unmarshal(rec.Body.Bytes(), &parsed)
 	return rec, parsed
+}
+
+func TestConfiguredBasePath(t *testing.T) {
+	tests := map[string]struct {
+		value string
+		want  string
+	}{
+		"unset":           {want: ""},
+		"root":            {value: "/", want: ""},
+		"absolute path":   {value: "/filabridge", want: "/filabridge"},
+		"relative path":   {value: "filabridge", want: "/filabridge"},
+		"trailing slash":  {value: "/filabridge/", want: "/filabridge"},
+		"normalizes path": {value: "/proxy/./apps//filabridge/", want: "/proxy/apps/filabridge"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("FILABRIDGE_BASE_PATH", tc.value)
+			if got := configuredBasePath(); got != tc.want {
+				t.Errorf("configuredBasePath() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestConfiguredBasePathRoutesAndRendersAllPages(t *testing.T) {
+	basePath := "/api/hassio_ingress/test-token/"
+	ws, _, _ := newTestServerAtBasePath(t, strings.TrimSuffix(basePath, "/"))
+
+	pages := map[string]struct {
+		path  string
+		links []string
+	}{
+		"dashboard": {
+			path: basePath,
+			links: []string{
+				`<link rel="stylesheet" href="` + basePath + `static/css/main.css">`,
+				`<script src="` + basePath + `static/js/websocket.js"></script>`,
+			},
+		},
+		"standalone": {
+			path: basePath + "api/nfc/assign",
+			links: []string{
+				`<link rel="stylesheet" href="` + basePath + `static/css/v2/tokens.css">`,
+				`<a href="` + basePath + `" class="back-button">Back to Dashboard</a>`,
+			},
+		},
+	}
+
+	for name, page := range pages {
+		t.Run(name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, page.path, nil)
+			rec := httptest.NewRecorder()
+			ws.router.ServeHTTP(rec, req)
+			body := rec.Body.String()
+
+			if !strings.Contains(body, `<base href="`+basePath+`">`) {
+				t.Fatalf("page did not render configured base path: %s", body)
+			}
+			for _, link := range page.links {
+				if !strings.Contains(body, link) {
+					t.Errorf("page missing prefixed link %q", link)
+				}
+			}
+		})
+	}
+
+	for _, requestPath := range []string{"/", "/api/status", "/static/css/main.css"} {
+		req := httptest.NewRequest(http.MethodGet, requestPath, nil)
+		rec := httptest.NewRecorder()
+		ws.router.ServeHTTP(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("unprefixed %s returned %d, want 404", requestPath, rec.Code)
+		}
+	}
+
+	for _, requestPath := range []string{basePath + "api/status", basePath + "static/css/main.css"} {
+		req := httptest.NewRequest(http.MethodGet, requestPath, nil)
+		rec := httptest.NewRecorder()
+		ws.router.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("prefixed %s returned %d, want 200", requestPath, rec.Code)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	ws.router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("root healthcheck returned %d, want 200", rec.Code)
+	}
+}
+
+func TestFrontendRequestsUseDocumentBase(t *testing.T) {
+	rootFetch := regexp.MustCompile(`fetch\(\s*['\x60"]\/api\/`)
+	for _, name := range []string{"main.js", "dropdowns.js", "printers.js", "websocket.js", "nfc.js"} {
+		data, err := staticFS.ReadFile("static/js/" + name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if rootFetch.Match(data) {
+			t.Errorf("%s contains a fetch that bypasses the document base", name)
+		}
+	}
+
+	websocketJS, err := staticFS.ReadFile("static/js/websocket.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(websocketJS), "new URL('ws/status', document.baseURI)") {
+		t.Error("WebSocket URL is not resolved against the document base")
+	}
+
+	tokensCSS, err := staticFS.ReadFile("static/css/v2/tokens.css")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(tokensCSS), "url('/static/") {
+		t.Error("font URL bypasses the Ingress base path")
+	}
+}
+
+func TestNFCURLsHonorConfiguredBasePath(t *testing.T) {
+	ws, _, spoolman := newTestServerAtBasePath(t, "/filabridge")
+	spoolman.Spools[7] = &fakeSpool{ID: 7, Name: "Violet", RemainingWeight: 750}
+
+	req := httptest.NewRequest(http.MethodGet, "/filabridge/api/nfc/urls", nil)
+	req.Host = "172.30.33.4:5000"
+	req.Header.Set("X-Forwarded-Host", "ha.example.com")
+	req.Header.Set("X-Forwarded-Proto", "https")
+	rec := httptest.NewRecorder()
+	ws.router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("NFC URLs = %d: %s", rec.Code, rec.Body.String())
+	}
+	var payload struct {
+		URLs []struct {
+			Type     string `json:"type"`
+			URL      string `json:"url"`
+			ComboURL string `json:"combo_url"`
+		} `json:"urls"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "https://ha.example.com/filabridge/api/nfc/assign?spool=7"
+	for _, item := range payload.URLs {
+		if item.Type == "spool" && item.URL == want {
+			if !strings.HasPrefix(item.ComboURL, want+"&location=") {
+				t.Errorf("combo URL = %q, want prefix %q", item.ComboURL, want+"&location=")
+			}
+			return
+		}
+	}
+	t.Errorf("spool URL %q not found in response: %s", want, rec.Body.String())
 }
 
 // TestDeveloperModeFlag: the dashboard exposes FILABRIDGE_DEVELOPER_MODE to the


### PR DESCRIPTION
I'm looking to put FilaBridge behind a path-prefix reverse proxy.  This change adds a `FILABRIDGE_BASE_PATH` (defaulting to the existing behavior if unset) that ensures that all URLs generated by the application match the proxy.

Generated NFC URLs extract the appropriate hostname from the standard `X-Forwarded-Host` and `X-Forwarded-Proto` headers.